### PR TITLE
Possible way to fix part of the difficulty lock

### DIFF
--- a/MapEditor/RagnarockMap.cs
+++ b/MapEditor/RagnarockMap.cs
@@ -203,7 +203,7 @@ public class RagnarockMap {
                         var val = Helper.DoubleParseInvariant((string)dbItem[i.Key]);
                         // special case
                         if (i.Key == "_difficultyRank") {
-                            if (val < 1 || 10 < val) {
+                            if (val < 1 || 99 < val) {
                                 throw new Exception($"Bad value for key {i.Key}");
                             }
                         } else if (!Helper.DoubleRangeCheck(val, expectedValuesL3[i.Key].Item1, expectedValuesL3[i.Key].Item2)) {


### PR DESCRIPTION
(untested, but it seems like a simple thing to fix)

As of the current update, you have to manually edit the difficulty value in info.dat if you want to go above 10. This change *should* allow maps with modified info.dat difficulties to load unless I'm being stupid about it.