### PR TITLE
Recently Opened doesn't show updated song name

### DIFF
--- a/Windows/MainWindow.UIControls.cs
+++ b/Windows/MainWindow.UIControls.cs
@@ -168,6 +168,7 @@ namespace Edda {
             // update the name of the map in recently opened folders
             recentMaps.RemoveRecentlyOpened(beatMap.GetPath());
             recentMaps.AddRecentlyOpened((string)beatMap.GetValue("_songName"), beatMap.GetPath());
+            recentMaps.Write();
 
         }
         private void TxtSongName_LostFocus(object sender, RoutedEventArgs e) {


### PR DESCRIPTION
Fixed an issue with old song title still appearing in Recently Opened after it's been changed in the editor and saved.

Steps to reproduce on v1.1.0:
1. Open Edda.
2. Select "New Map".
3. Select folder and song file.
4. Change the Song Name in the editor and save.
5. Close Edda and open it again.

Expected outcome: the new map is visible at the top of Recently Opened with the new Song Name.
Actual outcome: the new map is visible at the top of Recently Opened as "Untitled Map".