### PR TITLE
Improvements in UX when changing Beat Division

### DIFF
--- a/Classes/Helper.cs
+++ b/Classes/Helper.cs
@@ -37,6 +37,9 @@ public class Helper {
         double higher = Math.Max(x, y);
         return lower <= a && a <= higher;
     }
+    public static double DoubleRangeTruncate(double a, double x, double y) {
+        return Math.Min(Math.Max(a, x), y);
+    }
     public static string TimeFormat(int seconds) {
         int min = seconds / 60;
         int sec = seconds % 60;

--- a/Windows/MainWindow.UIControls.cs
+++ b/Windows/MainWindow.UIControls.cs
@@ -229,9 +229,9 @@ namespace Edda {
         private void AppMainWindow_PreviewMouseWheel(object sender, MouseWheelEventArgs e) {
             if (ctrlKeyDown) {
                 var delta = (int) Helper.DoubleRangeTruncate(e.Delta, -1, 1);
-                var currentBeatDivision = (int) double.Parse((string)mapEditor.GetMapValue("_editorGridDivision", RagnarockMapDifficulties.Current, custom: true));
+                int currentBeatDivision;
                 int.TryParse(txtGridDivision.Text, out currentBeatDivision);
-                txtGridDivision.Text = ((int)Helper.DoubleRangeTruncate(int.Parse(txtGridDivision.Text) + delta, 1, Editor.GridDivisionMax)).ToString();
+                txtGridDivision.Text = ((int)Helper.DoubleRangeTruncate(currentBeatDivision + delta, 1, Editor.GridDivisionMax)).ToString();
                 e.Handled = true; // Mark tunneling event as handled to prevent scrolling on the grid while changing the division.
             }
         }

--- a/Windows/MainWindow.UIControls.cs
+++ b/Windows/MainWindow.UIControls.cs
@@ -54,6 +54,9 @@ namespace Edda {
 
             if (e.Key == Key.LeftCtrl || e.Key == Key.RightCtrl) {
                 ctrlKeyDown = true;
+                if (!ctrlScrollGridDivision.HasValue) {
+                    ctrlScrollGridDivision = double.Parse((string)mapEditor.GetMapValue("_editorGridDivision", RagnarockMapDifficulties.Current, custom: true));
+                }
             }
             if (e.Key == Key.LeftShift || e.Key == Key.RightShift) {
                 shiftKeyDown = true;
@@ -167,6 +170,10 @@ namespace Edda {
         private void AppMainWindow_KeyUp(object sender, KeyEventArgs e) {
             if (e.Key == Key.LeftCtrl || e.Key == Key.RightCtrl) {
                 ctrlKeyDown = false;
+                if (ctrlScrollGridDivision.HasValue) {
+                    TxtGridDivision_LostFocus(sender, null);
+                    ctrlScrollGridDivision = null;
+                }
             }
             if (e.Key == Key.LeftShift || e.Key == Key.RightShift) {
                 shiftKeyDown = false;
@@ -222,6 +229,15 @@ namespace Edda {
                     BtnSongPlayer_Click(null, null);
                 }
                 e.Handled = true;
+            }
+        }
+
+        private void AppMainWindow_PreviewMouseWheel(object sender, MouseWheelEventArgs e) {
+            if (ctrlKeyDown) {
+                var delta = Helper.DoubleRangeTruncate(e.Delta, -1, 1);
+                ctrlScrollGridDivision = Helper.DoubleRangeTruncate(ctrlScrollGridDivision.Value + delta, 1, Editor.GridDivisionMax); 
+                txtGridDivision.Text = ((int)ctrlScrollGridDivision).ToString();
+                e.Handled = true; // Mark tunneling event as handled to prevent scrolling on the grid while changing the division.
             }
         }
 
@@ -352,6 +368,11 @@ namespace Edda {
             }
             txtSongBPM.Text = BPM.ToString();
         }
+        private void TxtSongBPM_KeyDown(object sender, KeyEventArgs e) {
+            if (e.Key == Key.Return) {
+                TxtSongBPM_LostFocus(sender, e);
+            }
+        }
         private void BtnChangeBPM_Click(object sender, RoutedEventArgs e) {
             var win = Helper.GetFirstWindow<ChangeBPMWindow>();
             if (win == null) {
@@ -415,6 +436,11 @@ namespace Edda {
                 level = prevLevel;
             }
             txtDifficultyNumber.Text = level.ToString();
+        }
+        private void TxtDifficultyNumber_KeyDown(object sender, KeyEventArgs e) {
+            if (e.Key == Key.Return) {
+                TxtDifficultyNumber_LostFocus(sender, null);
+            }
         }
         private void TxtNoteSpeed_LostFocus(object sender, RoutedEventArgs e) {
             double prevSpeed = int.Parse((string)mapEditor.GetMapValue("_noteJumpMovementSpeed", RagnarockMapDifficulties.Current));
@@ -483,6 +509,11 @@ namespace Edda {
             }
             txtGridSpacing.Text = spacing.ToString();
         }
+        private void TxtGridSpacing_KeyDown(object sender, KeyEventArgs e) {
+            if (e.Key == Key.Return) {
+                TxtGridSpacing_LostFocus(sender, null);
+            }
+        }
         private void TxtGridDivision_LostFocus(object sender, RoutedEventArgs e) {
             int prevDiv = int.Parse((string)mapEditor.GetMapValue("_editorGridDivision", RagnarockMapDifficulties.Current, custom: true));
             int div;
@@ -498,6 +529,11 @@ namespace Edda {
                 div = prevDiv;
             }
             txtGridDivision.Text = div.ToString();
+        }
+        private void TxtGridDivision_KeyDown(object sender, KeyEventArgs e) {
+            if (e.Key == Key.Return) {
+                TxtGridDivision_LostFocus(sender, null);
+            }
         }
         private void CheckWaveform_Click(object sender, RoutedEventArgs e) {
             if (checkWaveform.IsChecked == true) {

--- a/Windows/MainWindow.UIControls.cs
+++ b/Windows/MainWindow.UIControls.cs
@@ -54,9 +54,6 @@ namespace Edda {
 
             if (e.Key == Key.LeftCtrl || e.Key == Key.RightCtrl) {
                 ctrlKeyDown = true;
-                if (!ctrlScrollGridDivision.HasValue) {
-                    ctrlScrollGridDivision = double.Parse((string)mapEditor.GetMapValue("_editorGridDivision", RagnarockMapDifficulties.Current, custom: true));
-                }
             }
             if (e.Key == Key.LeftShift || e.Key == Key.RightShift) {
                 shiftKeyDown = true;
@@ -170,10 +167,7 @@ namespace Edda {
         private void AppMainWindow_KeyUp(object sender, KeyEventArgs e) {
             if (e.Key == Key.LeftCtrl || e.Key == Key.RightCtrl) {
                 ctrlKeyDown = false;
-                if (ctrlScrollGridDivision.HasValue) {
-                    TxtGridDivision_LostFocus(sender, null);
-                    ctrlScrollGridDivision = null;
-                }
+                TxtGridDivision_LostFocus(sender, null);
             }
             if (e.Key == Key.LeftShift || e.Key == Key.RightShift) {
                 shiftKeyDown = false;
@@ -234,9 +228,10 @@ namespace Edda {
 
         private void AppMainWindow_PreviewMouseWheel(object sender, MouseWheelEventArgs e) {
             if (ctrlKeyDown) {
-                var delta = Helper.DoubleRangeTruncate(e.Delta, -1, 1);
-                ctrlScrollGridDivision = Helper.DoubleRangeTruncate(ctrlScrollGridDivision.Value + delta, 1, Editor.GridDivisionMax); 
-                txtGridDivision.Text = ((int)ctrlScrollGridDivision).ToString();
+                var delta = (int) Helper.DoubleRangeTruncate(e.Delta, -1, 1);
+                var currentBeatDivision = (int) double.Parse((string)mapEditor.GetMapValue("_editorGridDivision", RagnarockMapDifficulties.Current, custom: true));
+                int.TryParse(txtGridDivision.Text, out currentBeatDivision);
+                txtGridDivision.Text = ((int)Helper.DoubleRangeTruncate(int.Parse(txtGridDivision.Text) + delta, 1, Editor.GridDivisionMax)).ToString();
                 e.Handled = true; // Mark tunneling event as handled to prevent scrolling on the grid while changing the division.
             }
         }

--- a/Windows/MainWindow.xaml
+++ b/Windows/MainWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
         WindowStartupLocation="CenterScreen"
-        x:Name="AppMainWindow" Title="Edda" Height="870" Width="1000" MinHeight="450" MinWidth="1000" Closed="AppMainWindow_Closed" KeyDown="AppMainWindow_KeyDown" KeyUp="AppMainWindow_KeyUp" PreviewKeyDown="AppMainWindow_PreviewKeyDown" Closing="AppMainWindow_Closing" Loaded="AppMainWindow_Loaded">
+        x:Name="AppMainWindow" Title="Edda" Height="870" Width="1000" MinHeight="450" MinWidth="1000" Closed="AppMainWindow_Closed" KeyDown="AppMainWindow_KeyDown" KeyUp="AppMainWindow_KeyUp" PreviewKeyDown="AppMainWindow_PreviewKeyDown" PreviewMouseWheel="AppMainWindow_PreviewMouseWheel" Closing="AppMainWindow_Closing" Loaded="AppMainWindow_Loaded">
     <DockPanel>
         <Border DockPanel.Dock="Top" Name="TopPanel" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" BorderThickness="0, 0, 0, 1">
             <Border.Background>
@@ -166,7 +166,7 @@
 
                         <Border Grid.Row="4" Grid.Column="1" >
                             <StackPanel Orientation="Horizontal">
-                                <TextBox Width="40" x:Name="txtSongBPM" Grid.Row="0" Grid.Column="1" LostFocus="TxtSongBPM_LostFocus"/>
+                                <TextBox Width="40" x:Name="txtSongBPM" Grid.Row="0" Grid.Column="1" LostFocus="TxtSongBPM_LostFocus" KeyDown="TxtSongBPM_KeyDown"/>
                                 <TextBlock VerticalAlignment="Center" Width="25" Margin="5 0 5 0">BPM</TextBlock>
                             </StackPanel>
                         </Border>
@@ -332,7 +332,7 @@
                             </Border>
 
                             <Border Grid.Row="0" Grid.Column="1" Padding="5 5 10 5">
-                                <TextBox x:Name="txtDifficultyNumber" Width="30" HorizontalAlignment="Left" LostFocus="TxtDifficultyNumber_LostFocus"/>
+                                <TextBox x:Name="txtDifficultyNumber" Width="30" HorizontalAlignment="Left" LostFocus="TxtDifficultyNumber_LostFocus" KeyDown="TxtDifficultyNumber_KeyDown"/>
                             </Border>
 
                             <Border Grid.Row="1" Grid.Column="0">
@@ -491,7 +491,7 @@
                             <Border Grid.Row="8" Grid.Column="1">
                                 <StackPanel Orientation="Horizontal">
                                     <TextBlock Margin="0 0 3 0" VerticalAlignment="Center">1/</TextBlock>
-                                    <TextBox Width="30" x:Name="txtGridDivision" LostFocus="TxtGridDivision_LostFocus" VerticalAlignment="Center"/>
+                                    <TextBox Width="30" x:Name="txtGridDivision" LostFocus="TxtGridDivision_LostFocus" KeyDown="TxtGridDivision_KeyDown" VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Border>
 
@@ -500,7 +500,7 @@
                             </Border>
 
                             <Border Grid.Row="9" Grid.Column="1" Padding="5 5 10 5">
-                                <TextBox x:Name="txtGridSpacing" HorizontalAlignment="Left" Width="30" LostFocus="TxtGridSpacing_LostFocus"/>
+                                <TextBox x:Name="txtGridSpacing" HorizontalAlignment="Left" Width="30" LostFocus="TxtGridSpacing_LostFocus" KeyDown="TxtGridSpacing_KeyDown"/>
                             </Border>
 
                             <Border Grid.Row="10" Grid.Column="0">

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -68,7 +68,6 @@ namespace Edda {
         UserSettingsManager userSettings;
         bool shiftKeyDown;
         bool ctrlKeyDown;
-        double? ctrlScrollGridDivision;
         bool returnToStartMenuOnClose = false;
 
         DoubleAnimation songPlayAnim;            // used for animating scroll when playing a song

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -68,6 +68,7 @@ namespace Edda {
         UserSettingsManager userSettings;
         bool shiftKeyDown;
         bool ctrlKeyDown;
+        double? ctrlScrollGridDivision;
         bool returnToStartMenuOnClose = false;
 
         DoubleAnimation songPlayAnim;            // used for animating scroll when playing a song


### PR DESCRIPTION
https://github.com/PKBeam/Edda/issues/29

Improvements in UX for several text boxes where user might expect feedback on clicking Enter.

Implemented new keyboard shortcut Ctrl+MouseWheel to make changing Beat Division on the fly more convenient. Scrolling updates the textbox, but the line re-rendering only happens when Ctrl is released for performance reasons.
**Note:** after this change, while Ctrl is pressed, scrolling on the grid is disabled. This might not be apparent to the user at first glance.