### PR TITLE
Selected cover image should be renamed to cover.jpg when copied to map directory

### DIFF
--- a/Classes/EddaConstants.cs
+++ b/Classes/EddaConstants.cs
@@ -173,6 +173,7 @@ namespace Edda.Const {
     public static class BeatmapDefaults {
         public const double BeatsPerMinute = 120;
         public const string SongFilename = "song.ogg";
+        public const string CoverFilename = "cover";
         public const int Shuffle = 0;           // what do
         public const double ShufflePeriod = 0.5;         // these do??
         public const string BeatmapCharacteristicName = "Standard";

--- a/Classes/Helper.cs
+++ b/Classes/Helper.cs
@@ -92,7 +92,16 @@ public class Helper {
     // File I/O
     public static string SanitiseSongFileName(string fileName) {
         //return fileName.Replace(" ", "-");
-        return "song.ogg";
+        return BeatmapDefaults.SongFilename;
+    }
+    public static string SanitiseCoverFileName(string fileName) {
+        // We'd like to use cover.* instead of the actual filename, as RagnaCustoms doesn't allow too long filenames there.
+        string coverExtension = Path.GetExtension(fileName);
+        if (coverExtension == ".jfif") {
+            // .jfif extension is not directly supported in RagnaRock, but the file can be easily converted into supported .jpeg by just renaming it.
+            coverExtension = ".jpeg";
+        }
+        return BeatmapDefaults.CoverFilename + coverExtension;
     }
     public static string DefaultRagnarockMapPath() {
         string docPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);

--- a/Classes/MapConverters/StepManiaMapConverter.cs
+++ b/Classes/MapConverters/StepManiaMapConverter.cs
@@ -190,14 +190,15 @@ public class StepManiaMapConverter : IMapConverter
         string coverImageFilename = smFile[SmFileAttribute.BANNER];
         if (coverImageFilename != string.Empty)
         {
-            string coverUrl = beatmap.PathOf(coverImageFilename);
+            string newCoverFilename = Helper.SanitiseCoverFileName(coverImageFilename);
+            string newCoverUrl = beatmap.PathOf(newCoverFilename);
             // can't copy over an existing file
-            if (File.Exists(coverUrl))
+            if (File.Exists(newCoverUrl))
             {
-                File.Delete(coverUrl);
+                File.Delete(newCoverUrl);
             }
-            File.Copy(Path.Combine(smFile.Directory, coverImageFilename), coverUrl);
-            beatmap.SetValue("_coverImageFilename", coverImageFilename);
+            File.Copy(Path.Combine(smFile.Directory, coverImageFilename), newCoverUrl);
+            beatmap.SetValue("_coverImageFilename", newCoverFilename);
         }
     }
 

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -704,7 +704,7 @@ namespace Edda {
 
         // song cover image
         private void SelectNewCoverImage() {
-            var d = new Microsoft.Win32.OpenFileDialog() { Filter = "JPEG Files|*.jpg;*.jpeg" };
+            var d = new Microsoft.Win32.OpenFileDialog() { Filter = "JPEG Files|*.jpg;*.jpeg;*.jfif" };
             d.Title = "Select a song to map";
 
             if (d.ShowDialog() != true) {
@@ -714,7 +714,7 @@ namespace Edda {
             imgCover.Source = null;
 
             string prevPath = Path.Combine(mapEditor.mapFolder, (string)mapEditor.GetMapValue("_coverImageFilename"));
-            string newFile = Path.GetFileName(d.FileName);
+            string newFile = Helper.SanitiseCoverFileName(d.FileName);
             string newPath = Path.Combine(mapEditor.mapFolder, newFile);
 
             // load new cover image, if necessary


### PR DESCRIPTION
#31 
Added support for JFIF cover images. Changed the behavior for selected cover images - they're copied over to the map folder as cover.(jpg|jpeg|jfif) instead of their actual filename.