### PR TITLE
Allow changing audio output device in Edda

### DIFF
--- a/Classes/Audio/DeviceChangeListener.cs
+++ b/Classes/Audio/DeviceChangeListener.cs
@@ -1,0 +1,67 @@
+using NAudio.CoreAudioApi;
+using NAudio.CoreAudioApi.Interfaces;
+using System.Windows;
+
+namespace Edda
+{
+    public class DeviceChangeListener : IMMNotificationClient
+    {
+        MainWindow caller;
+
+        public DeviceChangeListener(MainWindow caller)
+        {
+            this.caller = caller;
+        }
+
+        public void OnDefaultDeviceChanged(DataFlow flow, Role role, string defaultDeviceId)
+        {
+            if (flow == DataFlow.Render && role == Role.Multimedia && caller.playingOnDefaultDevice)
+            {
+                Application.Current.Dispatcher.BeginInvoke(() =>
+                {
+                    caller.UpdatePlaybackDevice(defaultDeviceId, true);
+                });
+            }
+        }
+
+        public void OnDeviceAdded(string pwstrDeviceId)
+        {
+            if (pwstrDeviceId == caller.userPreferredPlaybackDeviceID)
+            {
+                // User preferred device was readded, so switch to it.
+                Application.Current.Dispatcher.BeginInvoke(() =>
+                {
+                    caller.UpdatePlaybackDevice(pwstrDeviceId, false);
+                });
+            }
+        }
+
+        public void OnDeviceRemoved(string deviceId)
+        {
+            if (caller.playbackDeviceID == deviceId)
+            {
+                // We force an update to default device in this case.
+                Application.Current.Dispatcher.BeginInvoke(() =>
+                {
+                    caller.UpdatePlaybackDevice(null, true);
+                });
+            }
+        }
+
+        public void OnDeviceStateChanged(string deviceId, DeviceState newState)
+        {
+            if (caller.playbackDeviceID == deviceId && newState != DeviceState.Active) {
+                // If the current device is not active anymore, we force an update to default device.
+                Application.Current.Dispatcher.BeginInvoke(() =>
+                {
+                    caller.UpdatePlaybackDevice(null, true);
+                });
+            }
+        }
+
+        public void OnPropertyValueChanged(string pwstrDeviceId, PropertyKey key)
+        {
+            // Not needed.
+        }
+    }
+}

--- a/Classes/EddaConstants.cs
+++ b/Classes/EddaConstants.cs
@@ -58,6 +58,7 @@ namespace Edda.Const {
         public const string EnableSpectrogram = "enableSpectrogram";
         public const string DefaultNoteSpeed = "defaultNoteSpeed";
         public const string EditorAudioLatency = "editorAudioLatency";
+        public const string PlaybackDeviceID = "playbackDeviceID";
         public const string DrumSampleFile = "drumSampleFile";
         public const string PanDrumSounds = "panDrumSounds";
         public const string DefaultSongVolume = "defaultSongVolume";

--- a/Windows/MainWindow.UIControls.cs
+++ b/Windows/MainWindow.UIControls.cs
@@ -28,6 +28,12 @@ namespace Edda {
         }
         private void AppMainWindow_Closed(object sender, EventArgs e) {
             Trace.WriteLine("INFO: Closing main window...");
+            if (deviceEnumerator != null) {
+                if (deviceChangeListener != null) {
+                    deviceEnumerator.UnregisterEndpointNotificationCallback(deviceChangeListener);
+                }
+                deviceEnumerator.Dispose();
+            }
             songPlayer?.Stop();
             songPlayer?.Dispose();
             songStream?.Dispose();

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -852,7 +852,7 @@ namespace Edda {
             playbackDeviceID = newPlaybackDeviceID;
             playingOnDefaultDevice = isDefaultDevice;
             // Unfortunately, song is paused, so we can clean up old objects in peace. 
-            // When trying to do this while the song is still playing, there's some hart-to-track issues with 
+            // When trying to do this while the song is still playing, there's some hard-to-track issues with 
             // objects not being disposed correctly, resulting in memory leaks.
             PauseSong();
             if (songPlayer != null) {

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -95,48 +95,56 @@
                     </Grid.ColumnDefinitions>
 
                     <Border Grid.Row="0" Grid.Column="0">
-                        <TextBlock VerticalAlignment="Center">Audio Latency</TextBlock>
+                        <TextBlock VerticalAlignment="Center">Output Device</TextBlock>
                     </Border>
 
                     <Border Grid.Row="0" Grid.Column="1">
+                        <ComboBox x:Name="comboPlaybackDevice" DisplayMemberPath="Name" SelectionChanged="ComboPlaybackDevice_SelectionChanged" VerticalAlignment="Center"/>
+                    </Border>
+
+                    <Border Grid.Row="1" Grid.Column="0">
+                        <TextBlock VerticalAlignment="Center">Audio Latency</TextBlock>
+                    </Border>
+
+                    <Border Grid.Row="1" Grid.Column="1">
                         <StackPanel Orientation="Horizontal">
                             <TextBox x:Name="txtAudioLatency" Width="80" LostFocus="TxtAudioLatency_LostFocus" VerticalAlignment="Center"/>
                             <Label>ms</Label>
                         </StackPanel>
                     </Border>
 
-                    <Border Grid.Row="1" Grid.Column="0">
+                    <Border Grid.Row="2" Grid.Column="0">
                         <TextBlock VerticalAlignment="Center">Note Sound</TextBlock>
                     </Border>
 
-                    <Border Grid.Row="1" Grid.Column="1">
+                    <Border Grid.Row="2" Grid.Column="1">
                         <ComboBox x:Name="comboDrumSample" SelectionChanged="ComboDrumSample_SelectionChanged" VerticalAlignment="Center"/>
                     </Border>
 
-                    <Border Grid.Row="2" Grid.Column="0">
+                    <Border Grid.Row="3" Grid.Column="0">
                         <TextBlock VerticalAlignment="Center">Pan Note Sounds</TextBlock>
                     </Border>
 
-                    <Border Grid.Row="2" Grid.Column="1">
+                    <Border Grid.Row="3" Grid.Column="1">
                         <CheckBox x:Name="checkPanNotes" Click="checkPanNotes_Click"/>
                     </Border>
 
-                    <Border Grid.Row="3" Grid.Column="0">
+                    <Border Grid.Row="4" Grid.Column="0">
                         <TextBlock FontSize="10.5"  VerticalAlignment="Center">Default Song Volume</TextBlock>
                     </Border>
 
-                    <Border Grid.Row="3" Grid.Column="1">
+                    <Border Grid.Row="4" Grid.Column="1">
                         <DockPanel>
                             <TextBlock x:Name="txtSongVol" DockPanel.Dock="Right" Width="30" Margin="5 0 0 0">0%</TextBlock>
                             <Slider x:Name="sliderSongVol" Maximum="1" ValueChanged="SliderSongVol_ValueChanged" IsMoveToPointEnabled="True" MouseLeftButtonUp="sliderSongVol_MouseLeftButtonUp" Thumb.DragCompleted="sliderSongVol_DragCompleted"/>
                         </DockPanel>
                     </Border>
 
-                    <Border Grid.Row="4" Grid.Column="0">
+                    <Border Grid.Row="5" Grid.Column="0">
                         <TextBlock FontSize="10.5" VerticalAlignment="Center">Default Note Volume</TextBlock>
                     </Border>
 
-                    <Border Grid.Row="4" Grid.Column="1">
+                    <Border Grid.Row="5" Grid.Column="1">
                         <DockPanel>
                             <TextBlock x:Name="txtDrumVol" DockPanel.Dock="Right" Width="30" Margin="5 0 0 0">0%</TextBlock>
                             <Slider x:Name="sliderDrumVol" Maximum="1" ValueChanged="SliderDrumVol_ValueChanged" IsMoveToPointEnabled="True" MouseLeftButtonUp="sliderDrumVol_MouseLeftButtonUp" Thumb.DragCompleted="sliderDrumVol_DragCompleted"/>


### PR DESCRIPTION
#32 
Implemented support for selecting preferred output device. 
Edda will also now listen for changes to devices in system and will adjust its output device accordingly.