### PR TITLE
#26 Implemented tracking for unsaved changes in the map editor 

### DIFF
--- a/Classes/MapEditor/MapEditor.cs
+++ b/Classes/MapEditor/MapEditor.cs
@@ -13,12 +13,22 @@ public class MapDifficulty {
     public List<BPMChange> bpmChanges;
     public List<Note> selectedNotes;
     public EditHistory<Note> editorHistory;
+    public bool needsSave {
+        get;
+        private set;
+    } = false;
     public MapDifficulty(List<Note> notes, List<BPMChange> bpmChanges, List<Bookmark> bookmarks) {
         this.bpmChanges = bpmChanges ?? new();
         this.bookmarks = bookmarks ?? new();
         this.notes = notes ?? new();
         this.selectedNotes = new();
         this.editorHistory = new(Editor.HistoryMaxSize);
+    }
+    public void MarkDirty() {
+        this.needsSave = true;
+    }
+    public void MarkSaved() {
+        this.needsSave = false;
     }
 }
 public enum RagnarockMapDifficulties {
@@ -43,6 +53,8 @@ public class MapEditor {
     MapDifficulty?[] difficultyMaps = new MapDifficulty[3];
     List<Note> clipboard;
 
+    bool needsSave = false;
+
     public int numDifficulties {
         get {
             return beatMap.numDifficulties;
@@ -55,6 +67,15 @@ public class MapEditor {
             }  else {
                 return difficultyMaps[currentDifficultyIndex];
             }
+        }
+    }
+    public bool saveIsNeeded {
+        get {
+            bool save = needsSave;
+            for (int i = 0; i < numDifficulties; ++i) {
+                save = save || (difficultyMaps[i]?.needsSave ?? false);
+            }
+            return save;
         }
     }
 
@@ -77,6 +98,10 @@ public class MapEditor {
     public void SaveMap() {
         SaveMap(currentDifficultyIndex);
         beatMap.SaveToFile();
+        needsSave = false;
+        for (int i = 0; i < numDifficulties; i++) {
+            difficultyMaps[i]?.MarkSaved();
+        }
     }
     public void SaveMap(int indx) {
         var thisDifficultyMap = difficultyMaps[indx];
@@ -87,6 +112,7 @@ public class MapEditor {
         }
     }
     public void ClearSelectedDifficulty() {
+        currentMapDifficulty?.MarkDirty();
         currentMapDifficulty?.notes.Clear();
         currentMapDifficulty?.bookmarks.Clear();
         currentMapDifficulty?.bpmChanges.Clear();
@@ -101,10 +127,12 @@ public class MapEditor {
         difficultyMaps[difficultyMaps.Length - 1] = null;
 
         beatMap.DeleteMap(indx);
+        needsSave = false; // beatMap.DeleteMap force-saves info.dat
 
         return currentDifficultyIndex <= beatMap.numDifficulties - 1;
     }
     public void CreateDifficulty(bool copyCurrentMarkers) {
+        needsSave = true; // beatMap.AddMap doesn't save info.dat (even though SwapMaps can do that later when sorting difficulties)
         beatMap.AddMap();
         int newMap = beatMap.numDifficulties - 1;
         if (copyCurrentMarkers) {
@@ -116,6 +144,9 @@ public class MapEditor {
             beatMap.GetBPMChangesForMap(newMap),
             beatMap.GetBookmarksForMap(newMap)
         );
+        if (copyCurrentMarkers) {
+            difficultyMaps[newMap]?.MarkDirty();
+        }
     }
     public void SelectDifficulty(int indx) {
         // before switching - save the notes for the current difficulty, if it still exists
@@ -127,6 +158,8 @@ public class MapEditor {
         currentDifficultyIndex = indx;
     }
     public void SortDifficulties() {
+        //needsSave = true; - not needed, SwapDifficulties updates info.dat if anything changes
+
         // bubble sort
         bool swap;
         do {
@@ -153,9 +186,11 @@ public class MapEditor {
         difficultyMaps[j] = temp;
 
         beatMap.SwapMaps(i, j);
+        needsSave = false; // beatMap.SwapMaps force-saves the info.dat
         parent.UpdateDifficultyButtons();
     }
     public void AddBPMChange(BPMChange b, bool redraw = true) {
+        currentMapDifficulty?.MarkDirty();
         currentMapDifficulty?.bpmChanges.Add(b);
         currentMapDifficulty?.bpmChanges.Sort();
         if (redraw) {
@@ -164,6 +199,7 @@ public class MapEditor {
         parent.RefreshBPMChanges();
     }
     public void RemoveBPMChange(BPMChange b, bool redraw = true) {
+        currentMapDifficulty?.MarkDirty();
         currentMapDifficulty?.bpmChanges.Remove(b);
         if (redraw) {
             parent.DrawEditorGrid(false);
@@ -171,18 +207,22 @@ public class MapEditor {
         parent.RefreshBPMChanges();
     }
     public void AddBookmark(Bookmark b) {
+        currentMapDifficulty?.MarkDirty();
         currentMapDifficulty?.bookmarks.Add(b);
         parent.DrawEditorGrid(false);
     }
     public void RemoveBookmark(Bookmark b) {
+        currentMapDifficulty?.MarkDirty();
         currentMapDifficulty?.bookmarks.Remove(b);
         parent.DrawEditorGrid(false);
     }
     public void RenameBookmark(Bookmark b, string newName) {
+        currentMapDifficulty?.MarkDirty();
         b.name = newName;
         parent.DrawEditorGrid(false);
     }
     public void AddNotes(List<Note> notes, bool updateHistory = true) {
+        currentMapDifficulty?.MarkDirty();
         List<Note> drawNotes = new();
         foreach (Note n in notes) {
             if (Helper.InsertSortedUnique(this.currentMapDifficulty?.notes, n)) {
@@ -203,7 +243,7 @@ public class MapEditor {
         AddNotes(new List<Note>() { n }, updateHistory);
     }
     public void RemoveNotes(List<Note> notes, bool updateHistory = true) {
-
+        currentMapDifficulty?.MarkDirty();
         // undraw the added notes
         parent.gridController.UndrawNotes(notes);
 
@@ -375,7 +415,11 @@ public class MapEditor {
         return beatMap.GetMedalDistanceForMap(MapDifficultyIndex(difficulty), (int)medal);
     }
     public void SetMedalDistance(RagnarockScoreMedals medal, int distance, RagnarockMapDifficulties? difficulty = null) {
-        beatMap.SetMedalDistanceForMap(MapDifficultyIndex(difficulty), (int)medal, distance);
+        int index = MapDifficultyIndex(difficulty);
+        if (index != -1) {
+            difficultyMaps[index]?.MarkDirty();
+        }
+        beatMap.SetMedalDistanceForMap(index, (int)medal, distance);
     }
     public JToken GetMapValue(string key, RagnarockMapDifficulties? difficulty = null, bool custom = false) {
         JToken result;
@@ -394,12 +438,14 @@ public class MapEditor {
     public void SetMapValue(string key, JToken value, RagnarockMapDifficulties? difficulty = null, bool custom = false) {
         if (difficulty != null) {
             int indx = difficulty == RagnarockMapDifficulties.Current ? currentDifficultyIndex : (int)difficulty;
+            difficultyMaps[indx]?.MarkDirty();
             if (custom) {
                 beatMap.SetCustomValueForDifficultyMap(indx, key, value);
             } else {
                 beatMap.SetValueForDifficultyMap(indx, key, value);
             }
         } else {
+            needsSave = true;
             beatMap.SetValue(key, value);
         }
     }
@@ -413,6 +459,7 @@ public class MapEditor {
         if (currentMapDifficulty == null) {
             return;
         }
+        currentMapDifficulty.MarkDirty();
 
         double scaleFactor = newBPM / oldBPM;
         foreach (var bc in currentMapDifficulty.bpmChanges) {

--- a/Classes/MapEditor/MapEditor.cs
+++ b/Classes/MapEditor/MapEditor.cs
@@ -13,10 +13,7 @@ public class MapDifficulty {
     public List<BPMChange> bpmChanges;
     public List<Note> selectedNotes;
     public EditHistory<Note> editorHistory;
-    public bool needsSave {
-        get;
-        private set;
-    } = false;
+    public bool needsSave = false;
     public MapDifficulty(List<Note> notes, List<BPMChange> bpmChanges, List<Bookmark> bookmarks) {
         this.bpmChanges = bpmChanges ?? new();
         this.bookmarks = bookmarks ?? new();
@@ -24,6 +21,7 @@ public class MapDifficulty {
         this.selectedNotes = new();
         this.editorHistory = new(Editor.HistoryMaxSize);
     }
+    // Utility functions for syntax clarity with MapDifficulty? variables.
     public void MarkDirty() {
         this.needsSave = true;
     }
@@ -53,7 +51,7 @@ public class MapEditor {
     MapDifficulty?[] difficultyMaps = new MapDifficulty[3];
     List<Note> clipboard;
 
-    bool needsSave = false;
+    public bool needsSave = false;
 
     public int numDifficulties {
         get {

--- a/Windows/ChangeBPMWindow.xaml
+++ b/Windows/ChangeBPMWindow.xaml
@@ -34,7 +34,7 @@
             <StackPanel Margin="15">
 
                 <Label Padding="0 0 0 5" FontWeight="Bold" FontFamily="Bahnschrift" FontSize="14">Timing Changes:</Label>
-                <DataGrid x:Name="dataBPMChange" Height="200" AutoGenerateColumns="False" CellEditEnding="dataBPMChange_CellEditEnding" CurrentCellChanged="dataBPMChange_CurrentCellChanged" RowEditEnding="dataBPMChange_RowEditEnding" AddingNewItem="dataBPMChange_AddingNewItem">
+                <DataGrid x:Name="dataBPMChange" Height="200" AutoGenerateColumns="False" CellEditEnding="dataBPMChange_CellEditEnding" CurrentCellChanged="dataBPMChange_CurrentCellChanged" RowEditEnding="dataBPMChange_RowEditEnding" AddingNewItem="dataBPMChange_AddingNewItem" CommandManager.PreviewExecuted="dataBPMChange_PreviewExecuted">
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="Global Beat" Binding="{Binding globalBeat}" Width="*"/>
                         <DataGridTextColumn Header="BPM" Binding="{Binding BPM}" Width="*"/>

--- a/Windows/ChangeBPMWindow.xaml.cs
+++ b/Windows/ChangeBPMWindow.xaml.cs
@@ -67,7 +67,6 @@ namespace Edda
         }
 
         private void dataBPMChange_CurrentCellChanged(object sender, EventArgs e) {
-            caller.mapEditor.currentMapDifficulty?.MarkDirty(); // This might be too aggressive - triggers even when just clicking on the data cell
             caller.DrawEditorGrid(false);
         }
 

--- a/Windows/ChangeBPMWindow.xaml.cs
+++ b/Windows/ChangeBPMWindow.xaml.cs
@@ -67,6 +67,7 @@ namespace Edda
         }
 
         private void dataBPMChange_CurrentCellChanged(object sender, EventArgs e) {
+            caller.mapEditor.currentMapDifficulty?.MarkDirty(); // This might be too aggressive - triggers even when just clicking on the data cell
             caller.DrawEditorGrid(false);
         }
 
@@ -79,12 +80,14 @@ namespace Edda
 
             dataBPMChange.ItemsSource = null;
             BPMChanges.Sort();
+            caller.mapEditor.currentMapDifficulty?.MarkDirty();
             caller.DrawEditorGrid(false);
             dataBPMChange.ItemsSource = this.BPMChanges;
         }
 
         private void dataBPMChange_AddingNewItem(object sender, AddingNewItemEventArgs e) {
             e.NewItem = new BPMChange(Math.Round(caller.sliderSongProgress.Value / 60000 * globalBPM, 3), caller.globalBPM, caller.gridController.gridDivision);
+            caller.mapEditor.currentMapDifficulty?.MarkDirty();
         }
     }
 }

--- a/Windows/ChangeBPMWindow.xaml.cs
+++ b/Windows/ChangeBPMWindow.xaml.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using Edda.Const;
 
 namespace Edda
@@ -87,6 +88,12 @@ namespace Edda
         private void dataBPMChange_AddingNewItem(object sender, AddingNewItemEventArgs e) {
             e.NewItem = new BPMChange(Math.Round(caller.sliderSongProgress.Value / 60000 * globalBPM, 3), caller.globalBPM, caller.gridController.gridDivision);
             caller.mapEditor.currentMapDifficulty?.MarkDirty();
+        }
+
+        private void dataBPMChange_PreviewExecuted(object sender, ExecutedRoutedEventArgs e) {
+            if (e.Command == DataGrid.DeleteCommand) {
+                caller.mapEditor.currentMapDifficulty?.MarkDirty();
+            }
         }
     }
 }

--- a/Windows/MainWindow.UIControls.cs
+++ b/Windows/MainWindow.UIControls.cs
@@ -375,31 +375,24 @@ namespace Edda {
             txtSongOffset.Text = offset.ToString();
         }
         private void TxtSongName_TextChanged(object sender, TextChangedEventArgs e) {
-            if (doneInit) {
-                mapEditor.SetMapValue("_songName", txtSongName.Text);
+            mapEditor.SetMapValue("_songName", txtSongName.Text);
 
-                // update the name of the map in recently opened folders
-                recentMaps.RemoveRecentlyOpened(mapEditor.mapFolder);
-                recentMaps.AddRecentlyOpened((string)mapEditor.GetMapValue("_songName"), mapEditor.mapFolder);
-                recentMaps.Write();
-            }
-
+            // update the name of the map in recently opened folders
+            recentMaps.RemoveRecentlyOpened(mapEditor.mapFolder);
+            recentMaps.AddRecentlyOpened((string)mapEditor.GetMapValue("_songName"), mapEditor.mapFolder);
+            recentMaps.Write();
         }
         private void TxtSongName_LostFocus(object sender, RoutedEventArgs e) {
             txtSongName.ScrollToHome();
         }
         private void TxtArtistName_TextChanged(object sender, TextChangedEventArgs e) {
-            if (doneInit) {
-                mapEditor.SetMapValue("_songAuthorName", txtArtistName.Text);
-            }
+            mapEditor.SetMapValue("_songAuthorName", txtArtistName.Text);
         }
         private void TxtArtistName_LostFocus(object sender, RoutedEventArgs e) {
             txtArtistName.ScrollToHome();
         }
         private void TxtMapperName_TextChanged(object sender, TextChangedEventArgs e) {
-            if (doneInit) {
-                mapEditor.SetMapValue("_levelAuthorName", txtMapperName.Text);
-            }
+            mapEditor.SetMapValue("_levelAuthorName", txtMapperName.Text);
         }
         private void TxtMapperName_LostFocus(object sender, RoutedEventArgs e) {
             txtMapperName.ScrollToHome();
@@ -519,9 +512,7 @@ namespace Edda {
             //if (env == Constants.BeatmapDefaults.DefaultEnvironmentAlias) {
             //    env = "DefaultEnvironment";
             //}
-            if (doneInit) {
-                mapEditor.SetMapValue("_environmentName", (string)comboEnvironment.SelectedItem);
-            }
+            mapEditor.SetMapValue("_environmentName", (string)comboEnvironment.SelectedItem);
         }
     }
 }

--- a/Windows/MainWindow.UIControls.cs
+++ b/Windows/MainWindow.UIControls.cs
@@ -375,25 +375,31 @@ namespace Edda {
             txtSongOffset.Text = offset.ToString();
         }
         private void TxtSongName_TextChanged(object sender, TextChangedEventArgs e) {
-            mapEditor.SetMapValue("_songName", txtSongName.Text);
+            if (doneInit) {
+                mapEditor.SetMapValue("_songName", txtSongName.Text);
 
-            // update the name of the map in recently opened folders
-            recentMaps.RemoveRecentlyOpened(mapEditor.mapFolder);
-            recentMaps.AddRecentlyOpened((string)mapEditor.GetMapValue("_songName"), mapEditor.mapFolder);
-            recentMaps.Write();
+                // update the name of the map in recently opened folders
+                recentMaps.RemoveRecentlyOpened(mapEditor.mapFolder);
+                recentMaps.AddRecentlyOpened((string)mapEditor.GetMapValue("_songName"), mapEditor.mapFolder);
+                recentMaps.Write();
+            }
 
         }
         private void TxtSongName_LostFocus(object sender, RoutedEventArgs e) {
             txtSongName.ScrollToHome();
         }
         private void TxtArtistName_TextChanged(object sender, TextChangedEventArgs e) {
-            mapEditor.SetMapValue("_songAuthorName", txtArtistName.Text);
+            if (doneInit) {
+                mapEditor.SetMapValue("_songAuthorName", txtArtistName.Text);
+            }
         }
         private void TxtArtistName_LostFocus(object sender, RoutedEventArgs e) {
             txtArtistName.ScrollToHome();
         }
         private void TxtMapperName_TextChanged(object sender, TextChangedEventArgs e) {
-            mapEditor.SetMapValue("_levelAuthorName", txtMapperName.Text);
+            if (doneInit) {
+                mapEditor.SetMapValue("_levelAuthorName", txtMapperName.Text);
+            }
         }
         private void TxtMapperName_LostFocus(object sender, RoutedEventArgs e) {
             txtMapperName.ScrollToHome();
@@ -513,7 +519,9 @@ namespace Edda {
             //if (env == Constants.BeatmapDefaults.DefaultEnvironmentAlias) {
             //    env = "DefaultEnvironment";
             //}
-            mapEditor.SetMapValue("_environmentName", (string)comboEnvironment.SelectedItem);
+            if (doneInit) {
+                mapEditor.SetMapValue("_environmentName", (string)comboEnvironment.SelectedItem);
+            }
         }
     }
 }

--- a/Windows/MainWindow.UIControls.cs
+++ b/Windows/MainWindow.UIControls.cs
@@ -381,6 +381,7 @@ namespace Edda {
             recentMaps.RemoveRecentlyOpened(mapEditor.mapFolder);
             recentMaps.AddRecentlyOpened((string)mapEditor.GetMapValue("_songName"), mapEditor.mapFolder);
             recentMaps.Write();
+
         }
         private void TxtSongName_LostFocus(object sender, RoutedEventArgs e) {
             txtSongName.ScrollToHome();

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -69,6 +69,7 @@ namespace Edda {
         bool shiftKeyDown;
         bool ctrlKeyDown;
         bool returnToStartMenuOnClose = false;
+        bool doneInit = false;
 
         DoubleAnimation songPlayAnim;            // used for animating scroll when playing a song
         double prevScrollPercent = 0;       // percentage of scroll progress before the scroll viewport was changed
@@ -464,6 +465,7 @@ namespace Edda {
         private void InitUI() {
             // reset variables
             prevScrollPercent = 0;
+            doneInit = false;
 
             lineSongProgress.Y1 = borderNavWaveform.ActualHeight;
             lineSongProgress.Y2 = borderNavWaveform.ActualHeight;
@@ -498,6 +500,8 @@ namespace Edda {
             DrawEditorGrid();
             scrollEditor.ScrollToBottom();
             gridController.DrawNavWaveform();
+
+            doneInit = true;
         }
         private void EnableUI() {
             btnChangeDifficulty0.IsEnabled = true;
@@ -788,6 +792,7 @@ namespace Edda {
             btnAddDifficulty.IsEnabled = (mapEditor.numDifficulties < 3);
         }
         private void SwitchDifficultyMap(int indx) {
+            doneInit = false;
             PauseSong();
 
             mapEditor.SelectDifficulty(indx);
@@ -815,6 +820,7 @@ namespace Edda {
             UpdateDifficultyButtons();
             gridController.DrawNavBookmarks();
             DrawEditorGrid();
+            doneInit = true;
         }
 
         // song/note playback
@@ -1124,11 +1130,11 @@ namespace Edda {
             if (!mapIsLoaded) {
                 return true;
             }
-            var res = MessageBox.Show("Save the currently opened map?", "Warning", MessageBoxButton.YesNoCancel, MessageBoxImage.Warning);
-            if (res == MessageBoxResult.Yes) {
+            MessageBoxResult? res = null;
+            if (mapEditor.saveIsNeeded && (res = MessageBox.Show("There are some unsaved changes in the currently opened map. Do you want to save them?", "Warning", MessageBoxButton.YesNoCancel, MessageBoxImage.Warning)) == MessageBoxResult.Yes) {
                 BackupAndSaveBeatmap();
             }
-            return !(res == MessageBoxResult.Cancel);
+            return !(res.HasValue && res.Value == MessageBoxResult.Cancel);
         }
         internal void RefreshBPMChanges() {
             var win = Helper.GetFirstWindow<ChangeBPMWindow>();

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -69,7 +69,6 @@ namespace Edda {
         bool shiftKeyDown;
         bool ctrlKeyDown;
         bool returnToStartMenuOnClose = false;
-        bool doneInit = false;
 
         DoubleAnimation songPlayAnim;            // used for animating scroll when playing a song
         double prevScrollPercent = 0;       // percentage of scroll progress before the scroll viewport was changed
@@ -465,7 +464,8 @@ namespace Edda {
         private void InitUI() {
             // reset variables
             prevScrollPercent = 0;
-            doneInit = false;
+            
+            bool mapDirtyState = mapEditor.needsSave; // Store the "dirty" state of the map, so we can restore it after UI is initialized.
 
             lineSongProgress.Y1 = borderNavWaveform.ActualHeight;
             lineSongProgress.Y2 = borderNavWaveform.ActualHeight;
@@ -501,7 +501,7 @@ namespace Edda {
             scrollEditor.ScrollToBottom();
             gridController.DrawNavWaveform();
 
-            doneInit = true;
+            mapEditor.needsSave = mapDirtyState;
         }
         private void EnableUI() {
             btnChangeDifficulty0.IsEnabled = true;
@@ -792,10 +792,10 @@ namespace Edda {
             btnAddDifficulty.IsEnabled = (mapEditor.numDifficulties < 3);
         }
         private void SwitchDifficultyMap(int indx) {
-            doneInit = false;
             PauseSong();
 
             mapEditor.SelectDifficulty(indx);
+            bool difficultyDirtyState = mapEditor.currentMapDifficulty.needsSave; // Store the "dirty" state of the difficulty map, so we can restore it after UI is initialized.
 
             noteScanner = new NoteScanner(this, drummer);
             beatScanner = new BeatScanner(metronome);
@@ -820,7 +820,7 @@ namespace Edda {
             UpdateDifficultyButtons();
             gridController.DrawNavBookmarks();
             DrawEditorGrid();
-            doneInit = true;
+            mapEditor.currentMapDifficulty.needsSave = difficultyDirtyState; // Restore the "dirty" state before UI initialization.
         }
 
         // song/note playback


### PR DESCRIPTION
This is to avoid asking user to save when closing the map without any changes.

Separate tracking for info.dat and each difficulty map is implemented due to some actions having partial saving only on info.dat, but not on the difficulty maps.

I've had to add some initialization logic in MainWindow to avoid marking the map as "dirty" when map is first opened or difficulty is changed and the UI elements have their values programatically changed, as this resulted in poor user experience.