### PR TITLE
Fixed a few issues occuring when clicking during window initialization

### DIFF
--- a/Classes/Audio/VorbisSpectrogramGenerator.cs
+++ b/Classes/Audio/VorbisSpectrogramGenerator.cs
@@ -126,9 +126,8 @@ public class VorbisSpectrogramGenerator {
         return bitmapImage;
     }
     private void RecreateTokens() {
-        if (tokenSource != null) {
-            tokenSource.Dispose();
-        }
+        var oldTokenSource = tokenSource;
         tokenSource = new CancellationTokenSource();
+        oldTokenSource?.Dispose();
     }
 }

--- a/Classes/UI/EditorGridController.cs
+++ b/Classes/UI/EditorGridController.cs
@@ -343,13 +343,13 @@ public class EditorGridController {
     // grid drawing
     public void UpdateGridHeight() {
         // resize editor grid height to fit scrollEditor height
-        double beats = mapEditor.globalBPM / 60 * parentWindow.songTotalTimeInSeconds;
-        EditorGrid.Height = beats * unitLength + scrollEditor.ActualHeight;
+        if (parentWindow.songTotalTimeInSeconds.HasValue) {
+            double beats = mapEditor.globalBPM / 60 * parentWindow.songTotalTimeInSeconds.Value;
+            EditorGrid.Height = beats * unitLength + scrollEditor.ActualHeight;
+        }
     }
     public void DrawGrid(bool redrawWaveform = true) {
-        // resize editor grid height to fit scrollEditor height
-        double beats = mapEditor.globalBPM / 60 * parentWindow.songTotalTimeInSeconds;
-        EditorGrid.Height = beats * unitLength + scrollEditor.ActualHeight;
+        UpdateGridHeight();
 
         EditorGrid.Children.Clear();
 
@@ -663,10 +663,13 @@ public class EditorGridController {
         }
     }
     internal void DrawNavBookmarks() {
+        if (!parentWindow.songTotalTimeInSeconds.HasValue) {
+            return;
+        }
         canvasBookmarks.Children.Clear();
         canvasBookmarkLabels.Children.Clear();
         foreach (Bookmark b in mapEditor.currentMapDifficulty.bookmarks) {
-            var l = MakeLine(borderNavWaveform.ActualWidth, borderNavWaveform.ActualHeight * (1 - 60000 * b.beat / (mapEditor.globalBPM * parentWindow.songTotalTimeInSeconds * 1000)));
+            var l = MakeLine(borderNavWaveform.ActualWidth, borderNavWaveform.ActualHeight * (1 - 60000 * b.beat / (mapEditor.globalBPM * parentWindow.songTotalTimeInSeconds.Value * 1000)));
             l.Stroke = (SolidColorBrush)new BrushConverter().ConvertFrom(Editor.NavBookmark.Colour);
             l.StrokeThickness = Editor.NavBookmark.Thickness;
             l.Opacity = Editor.NavBookmark.Opacity;
@@ -936,8 +939,8 @@ public class EditorGridController {
             if (isMouseOnEditingGrid) {
                 beat = snapToGrid ? mouseBeatSnapped : mouseBeatUnsnapped;
                 // add bookmark on nav waveform
-            } else if (lineSongMouseover.Opacity > 0) {
-                beat = mapEditor.globalBPM * parentWindow.songTotalTimeInSeconds / 60000 * (1 - lineSongMouseover.Y1 / borderNavWaveform.ActualHeight);
+            } else if (lineSongMouseover.Opacity > 0 && parentWindow.songTotalTimeInSeconds.HasValue) {
+                beat = mapEditor.globalBPM * parentWindow.songTotalTimeInSeconds.Value / 60000 * (1 - lineSongMouseover.Y1 / borderNavWaveform.ActualHeight);
             }
         }
         mapEditor.AddBookmark(new Bookmark(beat, Editor.NavBookmark.DefaultName));
@@ -1006,7 +1009,7 @@ public class EditorGridController {
         return Helper.BitmapImageForBeat(beatNormalised, highlight);
     }
     private Label CreateBookmarkLabel(Bookmark b) {
-        var offset = borderNavWaveform.ActualHeight * (1 - 60000 * b.beat / (mapEditor.globalBPM * parentWindow.songTotalTimeInSeconds * 1000));
+        var offset = borderNavWaveform.ActualHeight * (1 - 60000 * b.beat / (mapEditor.globalBPM * parentWindow.songTotalTimeInSeconds.Value * 1000));
         var txtBlock = new Label();
         txtBlock.Foreground = (SolidColorBrush)new BrushConverter().ConvertFrom(Editor.NavBookmark.NameColour);
 

--- a/Windows/ChangeBPMWindow.xaml.cs
+++ b/Windows/ChangeBPMWindow.xaml.cs
@@ -43,7 +43,7 @@ namespace Edda
             string pendingEditText = ((TextBox)e.EditingElement).Text;
             // data validation
             try {
-                double pendingEdit = double.Parse(pendingEditText);
+                double pendingEdit = Helper.DoubleParseInvariant(pendingEditText);
                 // global beat
                 if (col == dataBPMChange.Columns[0].Header.ToString()) {
                     if (pendingEdit < 0) {

--- a/Windows/MainWindow.UIControls.cs
+++ b/Windows/MainWindow.UIControls.cs
@@ -34,13 +34,25 @@ namespace Edda {
                 }
                 deviceEnumerator.Dispose();
             }
-            songPlayer?.Stop();
-            songPlayer?.Dispose();
-            songStream?.Dispose();
+            var oldSongPlayer = songPlayer;
+            songPlayer = null;
+            oldSongPlayer?.Stop();
+            oldSongPlayer?.Dispose();
+
+            var oldSongStream = songStream;
+            songStream = null;
+            oldSongStream?.Dispose();
+
             noteScanner?.Stop();
             beatScanner?.Stop();
-            drummer?.Dispose();
-            metronome?.Dispose();
+
+            var oldDrummer = drummer;
+            drummer = null;
+            oldDrummer?.Dispose();
+
+            var oldMetronome = metronome;
+            metronome = null;
+            oldMetronome?.Dispose();
             Trace.WriteLine("INFO: Audio resources disposed...");
 
             // TODO find other stuff to dispose so we don't cause a memory leak

--- a/Windows/MainWindow.xaml
+++ b/Windows/MainWindow.xaml
@@ -638,7 +638,7 @@
                     </Grid>
                 </Grid>
                 <!-- Map Notes -->
-                <ScrollViewer x:Name="scrollEditor" VerticalScrollBarVisibility="Hidden" CanContentScroll="False" ScrollChanged="ScrollEditor_ScrollChanged" PreviewMouseWheel="ScrollEditor_PreviewMouseWheel" MouseMove="scrollEditor_MouseMove" MouseEnter="scrollEditor_MouseEnter" MouseLeave="scrollEditor_MouseLeave" PreviewMouseLeftButtonDown="scrollEditor_PreviewMouseLeftButtonDown" MouseLeftButtonUp="scrollEditor_PreviewMouseLeftButtonUp" MouseRightButtonUp="scrollEditor_PreviewMouseRightButtonUp">
+                <ScrollViewer x:Name="scrollEditor" VerticalScrollBarVisibility="Hidden" CanContentScroll="False" ScrollChanged="ScrollEditor_ScrollChanged" PreviewMouseWheel="ScrollEditor_PreviewMouseWheel" MouseMove="scrollEditor_MouseMove" MouseEnter="scrollEditor_MouseEnter" MouseLeave="scrollEditor_MouseLeave" PreviewMouseLeftButtonDown="scrollEditor_PreviewMouseLeftButtonDown" MouseLeftButtonUp="scrollEditor_PreviewMouseLeftButtonUp" MouseRightButtonUp="scrollEditor_PreviewMouseRightButtonUp" Loaded="scrollEditor_Loaded">
                     <Canvas x:Name="EditorGrid"/>
                 </ScrollViewer>
             </Grid>

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -42,9 +42,9 @@ namespace Edda {
                 sliderSongProgress.Value = value;
             }
         }
-        public double songTotalTimeInSeconds {
+        public double? songTotalTimeInSeconds {
             get {
-                return songStream.TotalTime.TotalSeconds;
+                return songStream?.TotalTime.TotalSeconds;
             }
         }
         bool mapIsLoaded {
@@ -205,9 +205,6 @@ namespace Edda {
                     BorderNavWaveform_SizeChanged(eventPattern.Sender, eventPattern.EventArgs)
                 )
             );
-
-            var vsg = new VorbisSpectrogramGenerator("C:\\Users\\Vincent Liu\\Documents\\Ragnarock\\CustomSongsWIP\\TheRedBaron\\song.ogg");
-            vsg.Draw(0, 0);
         }
 
        
@@ -862,8 +859,9 @@ namespace Edda {
             // objects not being disposed correctly, resulting in memory leaks.
             PauseSong();
             if (songPlayer != null) {
-                songPlayer.Dispose();
+                var oldSongPlayer = songPlayer;
                 InitSongPlayer();
+                oldSongPlayer.Dispose();
             }
             if (drummer != null) {
                 RestartDrummer();
@@ -966,10 +964,14 @@ namespace Edda {
         }
         private void UnloadSong() {
             if (songStream != null) {
-                songStream.Dispose();
+                var oldSongStream = songStream;
+                songStream = null;
+                oldSongStream.Dispose();
             }
             if (songPlayer != null) {
-                songPlayer.Dispose();
+                var oldSongPlayer = songPlayer;
+                songPlayer = null;
+                oldSongPlayer.Dispose();
             }
         }
         private void PlaySong() {
@@ -1023,8 +1025,9 @@ namespace Edda {
                 songPlayer.Play();
             } else {
                 songTempoStream.CurrentTime = new TimeSpan(0);
-                songPlaybackCancellationTokenSource.Dispose();
+                var oldSongPlaybackCancellationTokenSource = songPlaybackCancellationTokenSource;
                 songPlaybackCancellationTokenSource = new();
+                oldSongPlaybackCancellationTokenSource.Dispose();
                 Task.Delay(new TimeSpan(0, 0, 0, 0, editorAudioLatency)).ContinueWith(o => {
                     if (!songPlaybackCancellationTokenSource.IsCancellationRequested) {
                         songPlayer.Play();
@@ -1150,8 +1153,9 @@ namespace Edda {
             lineSongMouseover.StrokeThickness = Editor.NavPreviewLine.Thickness;
         }
         public void RestartMetronome() {
-            metronome?.Dispose();
+            var oldMetronome = metronome;
             InitMetronome();
+            oldMetronome?.Dispose();
         }
         private void InitMetronome() {
             metronome = new ParallelAudioPlayer(
@@ -1166,8 +1170,9 @@ namespace Edda {
             beatScanner?.SetAudioPlayer(metronome);
         }
         public void RestartDrummer() {
-            drummer?.Dispose();
+            var oldDrummer = drummer;
             InitDrummer();
+            oldDrummer?.Dispose();
         }
         private void InitDrummer() {
             drummer = new ParallelAudioPlayer(


### PR DESCRIPTION
I was investigating an issue with unintended notes being placed if you double-click the map you want to open and found some more issues that sometimes occur when clicking on elements that haven't been loaded in yet.

In particular, clicking on waveform/spectrogram while the map re-loads forces a re-draw from a different thread, which caused issues with some objects being still in disposed state from previously closing the map.