### PR TITLE
Spectrogram UX improvements

### DIFF
--- a/Classes/EddaConstants.cs
+++ b/Classes/EddaConstants.cs
@@ -54,6 +54,7 @@ namespace Edda.Const {
         public const int SpectrogramFrequency = Editor.Spectrogram.DefaultFreq;
         public const string SpectrogramColormap = "Blues";
         public const bool SpectrogramFlipped = false;
+        public const bool SpectrogramChunking = false;
         public const bool EnableDiscordRPC = true;
         public const bool EnableAutosave = true;
         public const bool CheckForUpdates = true;
@@ -76,6 +77,7 @@ namespace Edda.Const {
         public const string SpectrogramFrequency = "spectrogramFrequency";
         public const string SpectrogramColormap = "spectrogramColormap";
         public const string SpectrogramFlipped = "spectrogramFlipped";
+        public const string SpectrogramChunking = "spectrogramChunking";
         public const string EnableDiscordRPC = "enableDiscordRPC";
         public const string EnableAutosave = "enableAutosave";
         public const string CheckForUpdates = "checkForUpdates";
@@ -165,7 +167,8 @@ namespace Edda.Const {
             public const int DefaultFreq = 11_000; // Hz
             public const int FftSizeExp = 11; // FFT Size = 2^FftSizeExp
             public const int StepSize = 500; // samples
-            public const string CachedBmpFilenameFormat = "spectrogram_{0}_{1}_{2}_{3}.png";
+            public const int NumberOfChunks = 12; // Each chunk can span roughly 5 minutes before we reach the max pixel size of the bitmap.
+            public const string CachedBmpFilenameFormat = "spectrogram_{0}_{1}_{2}_{3}_*.png";
         }
 
     }

--- a/Classes/EddaConstants.cs
+++ b/Classes/EddaConstants.cs
@@ -50,6 +50,7 @@ namespace Edda.Const {
         public const bool PanDrumSounds = true;
         public const bool SpectrogramCache = true;
         public const string SpectrogramType = "Standard";
+        public const string SpectrogramQuality = "Medium";
         public const int SpectrogramFrequency = Editor.Spectrogram.DefaultFreq;
         public const string SpectrogramColormap = "Blues";
         public const bool SpectrogramFlipped = false;
@@ -71,6 +72,7 @@ namespace Edda.Const {
         public const string DefaultNoteVolume = "defaultNoteVolume";
         public const string SpectrogramCache = "spectrogramCache";
         public const string SpectrogramType = "spectrogramType";
+        public const string SpectrogramQuality = "spectrogramQuality";
         public const string SpectrogramFrequency = "spectrogramFrequency";
         public const string SpectrogramColormap = "spectrogramColormap";
         public const string SpectrogramFlipped = "spectrogramFlipped";
@@ -163,7 +165,7 @@ namespace Edda.Const {
             public const int DefaultFreq = 11_000; // Hz
             public const int FftSizeExp = 11; // FFT Size = 2^FftSizeExp
             public const int StepSize = 500; // samples
-            public const string CachedBmpFilenameFormat = "spectrogram_{0}_{1}_{2}.png";
+            public const string CachedBmpFilenameFormat = "spectrogram_{0}_{1}_{2}_{3}.png";
         }
 
     }

--- a/Classes/EddaConstants.cs
+++ b/Classes/EddaConstants.cs
@@ -35,6 +35,7 @@ namespace Edda.Const {
         public const string OldSettingsFile = "settings.txt";
         public const string ResourcesPath = "Resources/";
         public const string BackupPath = "autosaves";
+        public const string CachePath = "cache";
         public const int MaxBackups = 10;
 
     }
@@ -152,6 +153,7 @@ namespace Edda.Const {
             public const int FftSizeExp = 11; // FFT Size = 2^FftSizeExp
             public const int StepSize = 500; // samples
             public const string BackgroundColor = "#002655";
+            public const string CachedBmpFilename = "spectrogram.png";
         }
 
     }

--- a/Classes/EddaConstants.cs
+++ b/Classes/EddaConstants.cs
@@ -52,6 +52,7 @@ namespace Edda.Const {
         public const string SpectrogramType = "Standard";
         public const int SpectrogramFrequency = Editor.Spectrogram.DefaultFreq;
         public const string SpectrogramColormap = "Blues";
+        public const bool SpectrogramFlipped = false;
         public const bool EnableDiscordRPC = true;
         public const bool EnableAutosave = true;
         public const bool CheckForUpdates = true;
@@ -72,6 +73,7 @@ namespace Edda.Const {
         public const string SpectrogramType = "spectrogramType";
         public const string SpectrogramFrequency = "spectrogramFrequency";
         public const string SpectrogramColormap = "spectrogramColormap";
+        public const string SpectrogramFlipped = "spectrogramFlipped";
         public const string EnableDiscordRPC = "enableDiscordRPC";
         public const string EnableAutosave = "enableAutosave";
         public const string CheckForUpdates = "checkForUpdates";

--- a/Classes/EddaConstants.cs
+++ b/Classes/EddaConstants.cs
@@ -48,6 +48,10 @@ namespace Edda.Const {
         public const float DefaultSongVolume = 0.4F;
         public const float DefaultNoteVolume = 1;
         public const bool PanDrumSounds = true;
+        public const bool SpectrogramCache = true;
+        public const string SpectrogramType = "Standard";
+        public const int SpectrogramFrequency = Editor.Spectrogram.DefaultFreq;
+        public const string SpectrogramColormap = "Blues";
         public const bool EnableDiscordRPC = true;
         public const bool EnableAutosave = true;
         public const bool CheckForUpdates = true;
@@ -64,6 +68,10 @@ namespace Edda.Const {
         public const string PanDrumSounds = "panDrumSounds";
         public const string DefaultSongVolume = "defaultSongVolume";
         public const string DefaultNoteVolume = "defaultNoteVolume";
+        public const string SpectrogramCache = "spectrogramCache";
+        public const string SpectrogramType = "spectrogramType";
+        public const string SpectrogramFrequency = "spectrogramFrequency";
+        public const string SpectrogramColormap = "spectrogramColormap";
         public const string EnableDiscordRPC = "enableDiscordRPC";
         public const string EnableAutosave = "enableAutosave";
         public const string CheckForUpdates = "checkForUpdates";
@@ -147,13 +155,13 @@ namespace Edda.Const {
         }
 
         public static class Spectrogram {
-            public const int AmplitudeScale = 16_000;
-            public const int Width = 100;
-            public const int MaxFreq = 16_000; // Hz
+            public const int MelBinCount = 100;
+            public const int MinFreq = 100; // Hz
+            public const int MaxFreq = 22_000; // Hz
+            public const int DefaultFreq = 11_000; // Hz
             public const int FftSizeExp = 11; // FFT Size = 2^FftSizeExp
             public const int StepSize = 500; // samples
-            public const string BackgroundColor = "#002655";
-            public const string CachedBmpFilename = "spectrogram.png";
+            public const string CachedBmpFilenameFormat = "spectrogram_{0}_{1}_{2}.png";
         }
 
     }

--- a/Classes/UI/EditorGridController.cs
+++ b/Classes/UI/EditorGridController.cs
@@ -261,6 +261,9 @@ public class EditorGridController {
         audioWaveform = new VorbisWaveformGenerator(songPath);
         navWaveform = new VorbisWaveformGenerator(songPath);
     }
+    public void ClearCachedWaveforms() {
+        audioSpectrogram?.ClearCache();
+    }
     public void DrawScrollingWaveforms() {
         if (showWaveform) {
             DrawMainWaveform();

--- a/Classes/UI/EditorGridController.cs
+++ b/Classes/UI/EditorGridController.cs
@@ -32,11 +32,10 @@ public class EditorGridController {
     ColumnDefinition colWaveformVertical;
     Image imgWaveformVertical;
     ScrollViewer scrollSpectrogram;
-    Image imgSpectrogram;
-    RowDefinition rowSpectrogramLowerOffset;
-    RowDefinition rowSpectrogramUpperOffset;
+    StackPanel panelSpectrogram;
     Canvas canvasSpectrogramLowerOffset;
     Canvas canvasSpectrogramUpperOffset;
+    Image[] imgSpectrogramChunks;
     Grid editorMarginGrid;
     Canvas canvasNavInputBox;
     Canvas canvasBookmarks;
@@ -59,6 +58,7 @@ public class EditorGridController {
     public int spectrogramFrequency = Editor.Spectrogram.DefaultFreq;
     public string spectrogramColormap = Spectrogram.Colormap.Blues.Name;
     public bool spectrogramFlipped = false;
+    public bool? spectrogramChunking = null;
 
     // dynamically added controls
     Border dragSelectBorder = new();
@@ -175,11 +175,7 @@ public class EditorGridController {
         ColumnDefinition colWaveformVertical,
         Image imgWaveformVertical,
         ScrollViewer scrollSpectrogram,
-        Image imgSpectrogram,
-        RowDefinition rowSpectrogramLowerOffset,
-        RowDefinition rowSpectrogramUpperOffset,
-        Canvas canvasSpectrogramLowerOffset,
-        Canvas canvasSpectrogramUpperOffset,
+        StackPanel panelSpectrogram,
         Grid editorMarginGrid,
         Canvas canvasNavInputBox,
         Canvas canvasBookmarks,
@@ -195,11 +191,7 @@ public class EditorGridController {
         this.colWaveformVertical = colWaveformVertical;
         this.imgWaveformVertical = imgWaveformVertical;
         this.scrollSpectrogram = scrollSpectrogram;
-        this.imgSpectrogram = imgSpectrogram;
-        this.rowSpectrogramLowerOffset = rowSpectrogramLowerOffset;
-        this.rowSpectrogramUpperOffset = rowSpectrogramUpperOffset;
-        this.canvasSpectrogramLowerOffset = canvasSpectrogramLowerOffset;
-        this.canvasSpectrogramUpperOffset = canvasSpectrogramUpperOffset;
+        this.panelSpectrogram = panelSpectrogram;
         this.editorMarginGrid = editorMarginGrid;
         this.canvasNavInputBox = canvasNavInputBox;
         this.canvasBookmarks = canvasBookmarks;
@@ -211,7 +203,7 @@ public class EditorGridController {
         imgWaveformVertical.Opacity = Editor.NavWaveformOpacity;
         imgWaveformVertical.Stretch = Stretch.Fill;
 
-        imgSpectrogram.Stretch = Stretch.Fill;
+        SetupSpectrogramContent();
 
         lineSongMouseover.Opacity = 0;
 
@@ -325,11 +317,38 @@ public class EditorGridController {
             }
         });
     }
+    public void SetupSpectrogramContent() {
+        panelSpectrogram.Children.Clear();
+        // Upper offset
+        canvasSpectrogramUpperOffset = new Canvas();
+        canvasSpectrogramUpperOffset.SnapsToDevicePixels = true;
+        panelSpectrogram.Children.Add(canvasSpectrogramUpperOffset);
+        // Image chunks - inserted in inverse order
+        var numChunks = spectrogramChunking.HasValue ? (spectrogramChunking.Value ? Editor.Spectrogram.NumberOfChunks : 1) : 0;
+        imgSpectrogramChunks = new Image[numChunks];
+        for (int i = 0; i < numChunks; ++i) {
+            Image imgChunk = new Image();
+            imgChunk.Stretch = Stretch.Fill;
+            imgChunk.SnapsToDevicePixels = true;
+            imgSpectrogramChunks[i] = imgChunk;
+            panelSpectrogram.Children.Insert(1, imgChunk);
+        }
+        canvasSpectrogramLowerOffset = new Canvas();
+        canvasSpectrogramLowerOffset.SnapsToDevicePixels = true;
+        panelSpectrogram.Children.Add(canvasSpectrogramLowerOffset);
+    }
     private void ResizeSpectrogram() {
-        imgSpectrogram.Height = EditorGrid.Height - scrollEditor.ActualHeight;
-        imgSpectrogram.Width = scrollSpectrogram.ActualWidth;
-        rowSpectrogramLowerOffset.Height = new GridLength(unitHeight / 2);
-        rowSpectrogramUpperOffset.Height = new GridLength(scrollEditor.ActualHeight - (unitHeight / 2));        
+        // Upper offset
+        canvasSpectrogramUpperOffset.Height = scrollEditor.ActualHeight - (unitHeight / 2);
+        // Image chunks
+        var numChunks = imgSpectrogramChunks.Length;
+        for (int i = 0; i < numChunks; ++i) {
+            Image imgChunk = imgSpectrogramChunks[i];
+            imgChunk.Width = scrollSpectrogram.ActualWidth;
+            imgChunk.Height = (EditorGrid.Height - scrollEditor.ActualHeight) / (double) numChunks;
+        }
+        // Lower offset
+        canvasSpectrogramLowerOffset.Height = unitHeight / 2;
     }
     internal void DrawSpectrogram() {
         ResizeSpectrogram();
@@ -338,12 +357,17 @@ public class EditorGridController {
     private void CreateSpectrogram() {
         Task.Run(() => {
             DateTime before = DateTime.Now;
-            ImageSource bmp = audioSpectrogram.Draw(EditorGrid.ActualHeight, scrollSpectrogram.ActualWidth);
+            var numChunks = EditorGrid.ActualHeight == 0 || scrollSpectrogram.ActualWidth == 0 ? 0 : imgSpectrogramChunks.Length;
+            ImageSource[] bmps = audioSpectrogram.Draw(numChunks);
             Trace.WriteLine($"INFO: Drew spectrogram in {(DateTime.Now - before).TotalSeconds} sec");
 
-            if (bmp != null) {
+            if (bmps != null && bmps.Length == numChunks) {
                 this.dispatcher.Invoke(() => {
-                    imgSpectrogram.Source = bmp;
+                    for (int i = 0; i < numChunks; ++i) {
+                        if (bmps != null) {
+                            imgSpectrogramChunks[i].Source = bmps[i];
+                        }
+                    }
                     DrawingColor bgColor = audioSpectrogram.GetBackgroundColor();
                     var spectrogramBackgroundBrush = new SolidColorBrush(MediaColor.FromArgb(bgColor.A, bgColor.R, bgColor.G, bgColor.B));
                     canvasSpectrogramLowerOffset.Background = spectrogramBackgroundBrush;

--- a/Classes/UI/EditorGridController.cs
+++ b/Classes/UI/EditorGridController.cs
@@ -333,6 +333,7 @@ public class EditorGridController {
             imgSpectrogramChunks[i] = imgChunk;
             panelSpectrogram.Children.Insert(1, imgChunk);
         }
+        // Lower offset
         canvasSpectrogramLowerOffset = new Canvas();
         canvasSpectrogramLowerOffset.SnapsToDevicePixels = true;
         panelSpectrogram.Children.Add(canvasSpectrogramLowerOffset);

--- a/Classes/UI/EditorGridController.cs
+++ b/Classes/UI/EditorGridController.cs
@@ -55,6 +55,7 @@ public class EditorGridController {
     public bool? showSpectrogram = null;
     public bool spectrogramCache = true;
     public VorbisSpectrogramGenerator.SpectrogramType spectrogramType = VorbisSpectrogramGenerator.SpectrogramType.Standard;
+    public VorbisSpectrogramGenerator.SpectrogramQuality spectrogramQuality = VorbisSpectrogramGenerator.SpectrogramQuality.Medium;
     public int spectrogramFrequency = Editor.Spectrogram.DefaultFreq;
     public string spectrogramColormap = Spectrogram.Colormap.Blues.Name;
     public bool spectrogramFlipped = false;
@@ -265,12 +266,12 @@ public class EditorGridController {
 
     // waveform drawing
     public void InitWaveforms(string songPath) {
-        audioSpectrogram = new VorbisSpectrogramGenerator(songPath, spectrogramCache, spectrogramType, spectrogramFrequency, spectrogramColormap, spectrogramFlipped);
+        audioSpectrogram = new VorbisSpectrogramGenerator(songPath, spectrogramCache, spectrogramType, spectrogramQuality, spectrogramFrequency, spectrogramColormap, spectrogramFlipped);
         audioWaveform = new VorbisWaveformGenerator(songPath);
         navWaveform = new VorbisWaveformGenerator(songPath);
     }
     public void RefreshSpectrogramWaveform() {
-        audioSpectrogram?.InitSettings(spectrogramCache, spectrogramType, spectrogramFrequency, spectrogramColormap, spectrogramFlipped);
+        audioSpectrogram?.InitSettings(spectrogramCache, spectrogramType, spectrogramQuality, spectrogramFrequency, spectrogramColormap, spectrogramFlipped);
     }
     public void DrawScrollingWaveforms() {
         if (showWaveform) {

--- a/Classes/UI/EditorGridController.cs
+++ b/Classes/UI/EditorGridController.cs
@@ -14,6 +14,8 @@ using System.Windows.Media.Imaging;
 using Brushes = System.Windows.Media.Brushes;
 using System.Windows.Input;
 using Point = System.Windows.Point;
+using MediaColor = System.Windows.Media.Color;
+using DrawingColor = System.Drawing.Color;
 using Edda.Const;
 
 public class EditorGridController {
@@ -48,8 +50,13 @@ public class EditorGridController {
     public double gridSpacing;
     public int gridDivision;
     public bool showWaveform;
-    public bool? showSpectrogram = null;
     public bool snapToGrid = true;
+    // spectrogram settings
+    public bool? showSpectrogram = null;
+    public bool spectrogramCache = true;
+    public VorbisSpectrogramGenerator.SpectrogramType spectrogramType = VorbisSpectrogramGenerator.SpectrogramType.Standard;
+    public int spectrogramFrequency = Editor.Spectrogram.DefaultFreq;
+    public string spectrogramColormap = Spectrogram.Colormap.Blues.Name;
 
     // dynamically added controls
     Border dragSelectBorder = new();
@@ -257,12 +264,12 @@ public class EditorGridController {
 
     // waveform drawing
     public void InitWaveforms(string songPath) {
-        audioSpectrogram = new VorbisSpectrogramGenerator(songPath);
+        audioSpectrogram = new VorbisSpectrogramGenerator(songPath, spectrogramCache, spectrogramType, spectrogramFrequency, spectrogramColormap);
         audioWaveform = new VorbisWaveformGenerator(songPath);
         navWaveform = new VorbisWaveformGenerator(songPath);
     }
-    public void ClearCachedWaveforms() {
-        audioSpectrogram?.ClearCache();
+    public void RefreshSpectrogramWaveform() {
+        audioSpectrogram?.InitSettings(spectrogramCache, spectrogramType, spectrogramFrequency, spectrogramColormap);
     }
     public void DrawScrollingWaveforms() {
         if (showWaveform) {
@@ -335,7 +342,8 @@ public class EditorGridController {
             if (bmp != null) {
                 this.dispatcher.Invoke(() => {
                     imgSpectrogram.Source = bmp;
-                    var spectrogramBackgroundBrush = (SolidColorBrush)new BrushConverter().ConvertFrom(Editor.Spectrogram.BackgroundColor);
+                    DrawingColor bgColor = audioSpectrogram.GetBackgroundColor();
+                    var spectrogramBackgroundBrush = new SolidColorBrush(MediaColor.FromArgb(bgColor.A, bgColor.R, bgColor.G, bgColor.B));
                     canvasSpectrogramLowerOffset.Background = spectrogramBackgroundBrush;
                     canvasSpectrogramUpperOffset.Background = spectrogramBackgroundBrush;
                 });

--- a/Classes/UI/EditorGridController.cs
+++ b/Classes/UI/EditorGridController.cs
@@ -57,6 +57,7 @@ public class EditorGridController {
     public VorbisSpectrogramGenerator.SpectrogramType spectrogramType = VorbisSpectrogramGenerator.SpectrogramType.Standard;
     public int spectrogramFrequency = Editor.Spectrogram.DefaultFreq;
     public string spectrogramColormap = Spectrogram.Colormap.Blues.Name;
+    public bool spectrogramFlipped = false;
 
     // dynamically added controls
     Border dragSelectBorder = new();
@@ -264,12 +265,12 @@ public class EditorGridController {
 
     // waveform drawing
     public void InitWaveforms(string songPath) {
-        audioSpectrogram = new VorbisSpectrogramGenerator(songPath, spectrogramCache, spectrogramType, spectrogramFrequency, spectrogramColormap);
+        audioSpectrogram = new VorbisSpectrogramGenerator(songPath, spectrogramCache, spectrogramType, spectrogramFrequency, spectrogramColormap, spectrogramFlipped);
         audioWaveform = new VorbisWaveformGenerator(songPath);
         navWaveform = new VorbisWaveformGenerator(songPath);
     }
     public void RefreshSpectrogramWaveform() {
-        audioSpectrogram?.InitSettings(spectrogramCache, spectrogramType, spectrogramFrequency, spectrogramColormap);
+        audioSpectrogram?.InitSettings(spectrogramCache, spectrogramType, spectrogramFrequency, spectrogramColormap, spectrogramFlipped);
     }
     public void DrawScrollingWaveforms() {
         if (showWaveform) {

--- a/Windows/MainWindow.GridControls.cs
+++ b/Windows/MainWindow.GridControls.cs
@@ -3,6 +3,7 @@ using System;
 using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 using System.Windows.Input;
 
 namespace Edda {
@@ -51,6 +52,13 @@ namespace Edda {
             if (mapIsLoaded) {
                 gridController.DrawSpectrogram();
             }
+        }
+        private void ScrollSpectrogram_ScrollChanged(object sender, ScrollChangedEventArgs e) {
+            scrollEditor.ScrollToVerticalOffset(scrollSpectrogram.VerticalOffset);
+            ScrollEditor_ScrollChanged(null, e);
+        }
+        private void ScrollSpectrogram_PreviewMouseWheel(object sender, MouseWheelEventArgs e) {
+
         }
         private void ScrollEditor_SizeChanged(object sender, SizeChangedEventArgs e) {
             if (mapIsLoaded) {
@@ -124,6 +132,20 @@ namespace Edda {
         }
         private void scrollEditor_PreviewMouseRightButtonUp(object sender, MouseButtonEventArgs e) {
             gridController.GridRightMouseUp();
+        }
+    }
+
+    public class DoubleOffsetConverter : IValueConverter {
+        public double Offset {
+            get; set;
+        }
+
+        public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture) {
+            return (double) value - Offset;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture) {
+            return (double) value + Offset;
         }
     }
 }

--- a/Windows/MainWindow.GridControls.cs
+++ b/Windows/MainWindow.GridControls.cs
@@ -47,6 +47,11 @@ namespace Edda {
             lineSongMouseover.Opacity = 0;
             lblSelectedBeat.Content = "";
         }
+        private void BorderSpectrogram_SizeChanged(object sender, SizeChangedEventArgs e) {
+            if (mapIsLoaded) {
+                gridController.DrawSpectrogram();
+            }
+        }
         private void ScrollEditor_SizeChanged(object sender, SizeChangedEventArgs e) {
             if (mapIsLoaded) {
                 gridController.UpdateGridHeight();

--- a/Windows/MainWindow.MenuItems.cs
+++ b/Windows/MainWindow.MenuItems.cs
@@ -134,6 +134,13 @@ namespace Edda {
         private void MenuItemDifficultyPredictor_Click(object sender, RoutedEventArgs e) {
             ShowUniqueWindow(() => new DifficultyPredictorWindow(this));
         }
+
+        private void MenuItemClearCache_Click(object sender, RoutedEventArgs e) {
+            MessageBoxResult res = MessageBox.Show("This will delete all of the cached spectrogram images, which will cause it to load slower next time you open this map. Do you want to proceed?", "Warning", MessageBoxButton.YesNoCancel, MessageBoxImage.Warning);
+            if (res == MessageBoxResult.Yes) {
+                ClearSongCache();
+            }
+        }
         
         private void MenuItemSettings_Click(object sender, RoutedEventArgs e) {
             ShowUniqueWindow(() => new SettingsWindow(this, userSettings));

--- a/Windows/MainWindow.UIControls.cs
+++ b/Windows/MainWindow.UIControls.cs
@@ -249,6 +249,7 @@ namespace Edda {
             if (file == null) {
                 return;
             }
+            gridController.ClearCachedWaveforms();
             LoadSongFile(file);
         }
         private void BtnMakePreview_Click(object sender, RoutedEventArgs e) {

--- a/Windows/MainWindow.UIControls.cs
+++ b/Windows/MainWindow.UIControls.cs
@@ -249,7 +249,7 @@ namespace Edda {
             if (file == null) {
                 return;
             }
-            gridController.ClearCachedWaveforms();
+            ClearSongCache();
             LoadSongFile(file);
         }
         private void BtnMakePreview_Click(object sender, RoutedEventArgs e) {

--- a/Windows/MainWindow.xaml
+++ b/Windows/MainWindow.xaml
@@ -522,7 +522,7 @@
                 <ImageBrush ImageSource="/Resources/waterTexture.png" TileMode="Tile" ViewportUnits="Absolute" Viewport="0,0,256,256"/>
             </Grid.Background>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition x:Name="colSpectrogram" Width="*" MaxWidth="100"/>
+                <ColumnDefinition x:Name="colSpectrogram" Width="Auto"/>
                 <ColumnDefinition Width="5*"/>
                 <ColumnDefinition x:Name="colWaveformVertical" Width="*" MaxWidth="100"/>
             </Grid.ColumnDefinitions>
@@ -534,22 +534,6 @@
                     <Line x:Name="lineSongProgress" Stroke="Navy" StrokeThickness="1" X2="{Binding ElementName=borderNavWaveform, Path=ActualWidth}" Y1="{Binding ElementName=borderNavWaveform, Path=ActualHeight}" Y2="{Binding ElementName=borderNavWaveform, Path=ActualHeight}"/>
                     <Canvas x:Name="canvasBookmarkLabels"/>
                     <Canvas x:Name="canvasNavInputBox"/>
-                </Grid>
-            </Border>
-            <Border BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" BorderThickness="0 0 1 0">
-                <Grid Grid.Column="0">
-                    <ScrollViewer x:Name="scrollSpectrogram" VerticalScrollBarVisibility="Hidden" CanContentScroll="False" IsEnabled="False">
-                        <Grid Height="{Binding ElementName=EditorGrid, Path=ActualHeight}">
-                            <Grid.RowDefinitions>
-                                <RowDefinition x:Name="rowSpectrogramUpperOffset"/>
-                                <RowDefinition Height="*"/>
-                                <RowDefinition x:Name="rowSpectrogramLowerOffset"/>
-                            </Grid.RowDefinitions>
-                            <Canvas Grid.Row="2" Margin="-1" x:Name="canvasSpectrogramLowerOffset" />
-                            <Image Grid.Row="1" x:Name="imgSpectrogram"/>
-                            <Canvas Grid.Row="0" Margin="-1" x:Name="canvasSpectrogramUpperOffset" />
-                        </Grid>
-                    </ScrollViewer>
                 </Grid>
             </Border>
             <Grid Grid.Column="1" MaxWidth="600">
@@ -641,6 +625,29 @@
                 <ScrollViewer x:Name="scrollEditor" VerticalScrollBarVisibility="Hidden" CanContentScroll="False" ScrollChanged="ScrollEditor_ScrollChanged" PreviewMouseWheel="ScrollEditor_PreviewMouseWheel" MouseMove="scrollEditor_MouseMove" MouseEnter="scrollEditor_MouseEnter" MouseLeave="scrollEditor_MouseLeave" PreviewMouseLeftButtonDown="scrollEditor_PreviewMouseLeftButtonDown" MouseLeftButtonUp="scrollEditor_PreviewMouseLeftButtonUp" MouseRightButtonUp="scrollEditor_PreviewMouseRightButtonUp">
                     <Canvas x:Name="EditorGrid"/>
                 </ScrollViewer>
+            </Grid>
+            <Grid x:Name="gridSpectrogram" Grid.Column="0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="100" MinWidth="20"/>
+                    <ColumnDefinition Width="3"/>
+                </Grid.ColumnDefinitions>
+                <Border x:Name="borderSpectrogram" Grid.Column="0" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" BorderThickness="0 0 1 0">
+                    <Grid>
+                        <ScrollViewer x:Name="scrollSpectrogram" VerticalScrollBarVisibility="Hidden" CanContentScroll="False" IsEnabled="False">
+                            <Grid Height="{Binding ElementName=EditorGrid, Path=ActualHeight}">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition x:Name="rowSpectrogramUpperOffset"/>
+                                    <RowDefinition Height="*"/>
+                                    <RowDefinition x:Name="rowSpectrogramLowerOffset"/>
+                                </Grid.RowDefinitions>
+                                <Canvas Grid.Row="2" Margin="-1" x:Name="canvasSpectrogramLowerOffset" />
+                                <Image Grid.Row="1" x:Name="imgSpectrogram"/>
+                                <Canvas Grid.Row="0" Margin="-1" x:Name="canvasSpectrogramUpperOffset" />
+                            </Grid>
+                        </ScrollViewer>
+                    </Grid>
+                </Border>
+                <GridSplitter x:Name="spectrogramResize" Grid.Column="1" ResizeBehavior="PreviousAndCurrent" HorizontalAlignment="Center" VerticalAlignment="Stretch" ShowsPreview="True" Width="3"/>
             </Grid>
         </Grid>
     </DockPanel>

--- a/Windows/MainWindow.xaml
+++ b/Windows/MainWindow.xaml
@@ -647,7 +647,7 @@
                         </ScrollViewer>
                     </Grid>
                 </Border>
-                <GridSplitter x:Name="spectrogramResize" Grid.Column="1" ResizeBehavior="PreviousAndCurrent" HorizontalAlignment="Center" VerticalAlignment="Stretch" ShowsPreview="True" Width="3"/>
+                <GridSplitter x:Name="spectrogramResize" Grid.Column="1" ResizeBehavior="PreviousAndCurrent" HorizontalAlignment="Center" VerticalAlignment="Stretch" ShowsPreview="False" Width="3"/>
             </Grid>
         </Grid>
     </DockPanel>

--- a/Windows/MainWindow.xaml
+++ b/Windows/MainWindow.xaml
@@ -3,9 +3,14 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:edda="clr-namespace:Edda"
         mc:Ignorable="d"
         WindowStartupLocation="CenterScreen"
         x:Name="AppMainWindow" Title="Edda" Height="870" Width="1000" MinHeight="450" MinWidth="1000" Closed="AppMainWindow_Closed" KeyDown="AppMainWindow_KeyDown" KeyUp="AppMainWindow_KeyUp" PreviewKeyDown="AppMainWindow_PreviewKeyDown" PreviewMouseWheel="AppMainWindow_PreviewMouseWheel" Closing="AppMainWindow_Closing" Loaded="AppMainWindow_Loaded">
+    <Window.Resources>
+        <edda:DoubleOffsetConverter x:Key="SpectrogramColumnMaxWidthConverter" Offset="320"/>
+        <edda:DoubleOffsetConverter x:Key="SpectrogramResizeMaxWidthConverter" Offset="323"/>
+    </Window.Resources>
     <DockPanel>
         <Border DockPanel.Dock="Top" Name="TopPanel" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" BorderThickness="0, 0, 0, 1">
             <Border.Background>
@@ -470,7 +475,7 @@
                                 </StackPanel>
                             </Border>
 
-                            <Border Grid.Row="6" Grid.Column="0" Margin="0 3 0 0">
+                            <Border Grid.Row="6" Grid.ColumnSpan="2" Margin="0 3 0 0">
                                 <TextBlock VerticalAlignment="Center" FontWeight="Bold" FontSize="14" FontFamily="Bahnschrift">Editing Grid</TextBlock>
                             </Border>
 
@@ -522,9 +527,9 @@
                 <ImageBrush ImageSource="/Resources/waterTexture.png" TileMode="Tile" ViewportUnits="Absolute" Viewport="0,0,256,256"/>
             </Grid.Background>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition x:Name="colSpectrogram" Width="Auto"/>
-                <ColumnDefinition Width="5*"/>
-                <ColumnDefinition x:Name="colWaveformVertical" Width="*" MaxWidth="100"/>
+                <ColumnDefinition x:Name="colSpectrogram" Width="Auto" MaxWidth="{Binding ElementName=EditorPanel, Path=ActualWidth, Converter={StaticResource SpectrogramColumnMaxWidthConverter}}"/>
+                <ColumnDefinition Width="5*" MinWidth="300"/>
+                <ColumnDefinition x:Name="colWaveformVertical" Width="*" MaxWidth="100" MinWidth="20"/>
             </Grid.ColumnDefinitions>
             <Border x:Name="borderNavWaveform" Grid.Column="2" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" BorderThickness="1 0 0 0" Background="#20000000" MouseMove="BorderNavWaveform_MouseMove" MouseEnter="BorderNavWaveform_MouseEnter" MouseLeave="BorderNavWaveform_MouseLeave" MouseLeftButtonDown="BorderNavWaveform_MouseLeftButtonDown" MouseLeftButtonUp="BorderNavWaveform_MouseLeftButtonUp">
                 <Grid>
@@ -628,12 +633,12 @@
             </Grid>
             <Grid x:Name="gridSpectrogram" Grid.Column="0">
                 <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="100" MinWidth="20"/>
+                    <ColumnDefinition Width="100" MinWidth="20" MaxWidth="{Binding ElementName=EditorPanel, Path=ActualWidth, Converter={StaticResource SpectrogramResizeMaxWidthConverter}}"/>
                     <ColumnDefinition Width="3"/>
                 </Grid.ColumnDefinitions>
                 <Border x:Name="borderSpectrogram" Grid.Column="0" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" BorderThickness="0 0 1 0">
                     <Grid>
-                        <ScrollViewer x:Name="scrollSpectrogram" VerticalScrollBarVisibility="Hidden" CanContentScroll="False" IsEnabled="False">
+                        <ScrollViewer x:Name="scrollSpectrogram" VerticalScrollBarVisibility="Hidden" CanContentScroll="False" ScrollChanged="ScrollSpectrogram_ScrollChanged" PreviewMouseWheel="ScrollSpectrogram_PreviewMouseWheel">
                             <Grid Height="{Binding ElementName=EditorGrid, Path=ActualHeight}">
                                 <Grid.RowDefinitions>
                                     <RowDefinition x:Name="rowSpectrogramUpperOffset"/>
@@ -647,7 +652,7 @@
                         </ScrollViewer>
                     </Grid>
                 </Border>
-                <GridSplitter x:Name="spectrogramResize" Grid.Column="1" ResizeBehavior="PreviousAndCurrent" HorizontalAlignment="Center" VerticalAlignment="Stretch" ShowsPreview="False" Width="3"/>
+                <GridSplitter x:Name="spectrogramResize" Grid.Column="1" ResizeBehavior="PreviousAndCurrent" HorizontalAlignment="Left" VerticalAlignment="Stretch" ShowsPreview="False" Width="3"/>
             </Grid>
         </Grid>
     </DockPanel>

--- a/Windows/MainWindow.xaml
+++ b/Windows/MainWindow.xaml
@@ -641,16 +641,9 @@
                 <Border x:Name="borderSpectrogram" Grid.Column="0" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" BorderThickness="0 0 1 0">
                     <Grid>
                         <ScrollViewer x:Name="scrollSpectrogram" VerticalScrollBarVisibility="Hidden" CanContentScroll="False" ScrollChanged="ScrollSpectrogram_ScrollChanged" PreviewMouseWheel="ScrollSpectrogram_PreviewMouseWheel">
-                            <Grid Height="{Binding ElementName=EditorGrid, Path=ActualHeight}">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition x:Name="rowSpectrogramUpperOffset"/>
-                                    <RowDefinition Height="*"/>
-                                    <RowDefinition x:Name="rowSpectrogramLowerOffset"/>
-                                </Grid.RowDefinitions>
-                                <Canvas Grid.Row="2" Margin="-1" x:Name="canvasSpectrogramLowerOffset" />
-                                <Image Grid.Row="1" x:Name="imgSpectrogram"/>
-                                <Canvas Grid.Row="0" Margin="-1" x:Name="canvasSpectrogramUpperOffset" />
-                            </Grid>
+                            <StackPanel x:Name="panelSpectrogram" Height="{Binding ElementName=EditorGrid, Path=ActualHeight}">
+                                <!-- This is built dynamically to allow chunk-loading -->
+                            </StackPanel>
                         </ScrollViewer>
                     </Grid>
                 </Border>

--- a/Windows/MainWindow.xaml
+++ b/Windows/MainWindow.xaml
@@ -65,6 +65,7 @@
                         <MenuItem x:Name="MenuItemBpmFinder" Header="_BPM Finder" Click="MenuItemBpmFinder_Click"/>
                         <MenuItem x:Name="MenuItemDifficultyPredictor" Header="_Difficulty Predictor" Click="MenuItemDifficultyPredictor_Click"/>
                         <Separator />
+                        <MenuItem x:Name="MenuItemClearCache" Header="_Clear Cache" Click="MenuItemClearCache_Click"/>
                         <MenuItem x:Name="MenuItemSettings" Header="_Settings" Click="MenuItemSettings_Click"/>
                     </MenuItem>
                     <MenuItem Header="_Help">

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -206,8 +206,15 @@ namespace Edda {
                 )
             );
 
-            var vsg = new VorbisSpectrogramGenerator("C:\\Users\\Vincent Liu\\Documents\\Ragnarock\\CustomSongsWIP\\TheRedBaron\\song.ogg");
-            vsg.Draw(0, 0);
+            Observable
+            .FromEventPattern<SizeChangedEventArgs>(borderSpectrogram, nameof(SizeChanged))
+            .Throttle(TimeSpan.FromMilliseconds(Editor.DrawDebounceInterval))
+            .ObserveOn(SynchronizationContext.Current)
+            .Subscribe(eventPattern =>
+                AppMainWindow.Dispatcher.Invoke(() =>
+                    BorderSpectrogram_SizeChanged(eventPattern.Sender, eventPattern.EventArgs)
+                )
+            );
         }
 
        
@@ -718,14 +725,11 @@ namespace Edda {
             userSettings = new UserSettingsManager(Program.SettingsFile);
 
             var showSpectrogram = userSettings.GetBoolForKey(UserSettingsKey.EnableSpectrogram);
-            var oldValue = gridController.showSpectrogram;
             gridController.showSpectrogram = showSpectrogram;
             if (showSpectrogram) {
-                colSpectrogram.Width = new GridLength(1, GridUnitType.Star);
-                scrollSpectrogram.Visibility = Visibility.Visible;
+                gridSpectrogram.Visibility = Visibility.Visible;
             } else {
-                colSpectrogram.Width = new GridLength(0);
-                scrollSpectrogram.Visibility = Visibility.Collapsed;
+                gridSpectrogram.Visibility = Visibility.Collapsed;
             }
 
             int.TryParse(userSettings.GetValueForKey(UserSettingsKey.EditorAudioLatency), out editorAudioLatency);

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -710,6 +710,10 @@ namespace Edda {
                 userSettings.SetValueForKey(UserSettingsKey.SpectrogramColormap, DefaultUserSettings.SpectrogramColormap);
             }
 
+            if (userSettings.GetValueForKey(UserSettingsKey.SpectrogramFlipped) == null) {
+                userSettings.SetValueForKey(UserSettingsKey.SpectrogramFlipped, DefaultUserSettings.SpectrogramFlipped);
+            }
+
             if (userSettings.GetValueForKey(UserSettingsKey.EnableAutosave) == null) {
                 userSettings.SetValueForKey(UserSettingsKey.EnableAutosave, DefaultUserSettings.EnableAutosave);
             }
@@ -756,6 +760,7 @@ namespace Edda {
             int.TryParse(userSettings.GetValueForKey(UserSettingsKey.SpectrogramFrequency), out int spectrogramFrequency);
             gridController.spectrogramFrequency = spectrogramFrequency;
             gridController.spectrogramColormap = userSettings.GetValueForKey(UserSettingsKey.SpectrogramColormap);
+            gridController.spectrogramFlipped = userSettings.GetBoolForKey(UserSettingsKey.SpectrogramFlipped);
             if (reloadWaveforms) {
                 gridController.RefreshSpectrogramWaveform();
                 gridController.DrawSpectrogram();

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -700,6 +700,10 @@ namespace Edda {
                 userSettings.SetValueForKey(UserSettingsKey.SpectrogramType, DefaultUserSettings.SpectrogramType);
             }
 
+            if (userSettings.GetValueForKey(UserSettingsKey.SpectrogramQuality) == null) {
+                userSettings.SetValueForKey(UserSettingsKey.SpectrogramQuality, DefaultUserSettings.SpectrogramQuality);
+            }
+
             try {
                 int.Parse(userSettings.GetValueForKey(UserSettingsKey.SpectrogramFrequency));
             } catch {
@@ -754,9 +758,18 @@ namespace Edda {
                 gridSpectrogram.Visibility = Visibility.Collapsed;
             }
 
-            gridController.spectrogramCache = userSettings.GetBoolForKey(UserSettingsKey.SpectrogramCache);
+            var cacheSpectrogram = userSettings.GetBoolForKey(UserSettingsKey.SpectrogramCache);
+            gridController.spectrogramCache = cacheSpectrogram;
+            if (showSpectrogram && cacheSpectrogram) {
+                MenuItemClearCache.Visibility = Visibility.Visible;
+            } else {
+                MenuItemClearCache.Visibility = Visibility.Collapsed;
+            }
+
             Enum.TryParse(typeof(VorbisSpectrogramGenerator.SpectrogramType), userSettings.GetValueForKey(UserSettingsKey.SpectrogramType), out object spectrogramType);
             gridController.spectrogramType = (VorbisSpectrogramGenerator.SpectrogramType) spectrogramType;
+            Enum.TryParse(typeof(VorbisSpectrogramGenerator.SpectrogramQuality), userSettings.GetValueForKey(UserSettingsKey.SpectrogramQuality), out object spectrogramQuality);
+            gridController.spectrogramQuality = (VorbisSpectrogramGenerator.SpectrogramQuality) spectrogramQuality;
             int.TryParse(userSettings.GetValueForKey(UserSettingsKey.SpectrogramFrequency), out int spectrogramFrequency);
             gridController.spectrogramFrequency = spectrogramFrequency;
             gridController.spectrogramColormap = userSettings.GetValueForKey(UserSettingsKey.SpectrogramColormap);

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -692,6 +692,24 @@ namespace Edda {
                 userSettings.SetValueForKey(UserSettingsKey.DefaultNoteVolume, DefaultUserSettings.DefaultNoteVolume);
             }
 
+            if (userSettings.GetValueForKey(UserSettingsKey.SpectrogramCache) == null) {
+                userSettings.SetValueForKey(UserSettingsKey.SpectrogramCache, DefaultUserSettings.SpectrogramCache);
+            }
+
+            if (userSettings.GetValueForKey(UserSettingsKey.SpectrogramType) == null) {
+                userSettings.SetValueForKey(UserSettingsKey.SpectrogramType, DefaultUserSettings.SpectrogramType);
+            }
+
+            try {
+                int.Parse(userSettings.GetValueForKey(UserSettingsKey.SpectrogramFrequency));
+            } catch {
+                userSettings.SetValueForKey(UserSettingsKey.SpectrogramFrequency, DefaultUserSettings.SpectrogramFrequency);
+            }
+
+            if (userSettings.GetValueForKey(UserSettingsKey.SpectrogramColormap) == null) {
+                userSettings.SetValueForKey(UserSettingsKey.SpectrogramColormap, DefaultUserSettings.SpectrogramColormap);
+            }
+
             if (userSettings.GetValueForKey(UserSettingsKey.EnableAutosave) == null) {
                 userSettings.SetValueForKey(UserSettingsKey.EnableAutosave, DefaultUserSettings.EnableAutosave);
             }
@@ -720,7 +738,7 @@ namespace Edda {
 
             userSettings.Write();
         }
-        internal void LoadSettingsFile() {
+        internal void LoadSettingsFile(bool reloadWaveforms = false) {
 
             userSettings = new UserSettingsManager(Program.SettingsFile);
 
@@ -730,6 +748,17 @@ namespace Edda {
                 gridSpectrogram.Visibility = Visibility.Visible;
             } else {
                 gridSpectrogram.Visibility = Visibility.Collapsed;
+            }
+
+            gridController.spectrogramCache = userSettings.GetBoolForKey(UserSettingsKey.SpectrogramCache);
+            Enum.TryParse(typeof(VorbisSpectrogramGenerator.SpectrogramType), userSettings.GetValueForKey(UserSettingsKey.SpectrogramType), out object spectrogramType);
+            gridController.spectrogramType = (VorbisSpectrogramGenerator.SpectrogramType) spectrogramType;
+            int.TryParse(userSettings.GetValueForKey(UserSettingsKey.SpectrogramFrequency), out int spectrogramFrequency);
+            gridController.spectrogramFrequency = spectrogramFrequency;
+            gridController.spectrogramColormap = userSettings.GetValueForKey(UserSettingsKey.SpectrogramColormap);
+            if (reloadWaveforms) {
+                gridController.RefreshSpectrogramWaveform();
+                gridController.DrawSpectrogram();
             }
 
             int.TryParse(userSettings.GetValueForKey(UserSettingsKey.EditorAudioLatency), out editorAudioLatency);
@@ -960,6 +989,12 @@ namespace Edda {
                 gridController.InitWaveforms(songPath);
             }
             //awd = new AudioVisualiser_Float32(new VorbisWaveReader(songPath));
+        }
+        internal void ClearSongCache() {
+            var cacheDirectoryPath = Path.Combine(mapEditor.mapFolder, Program.CachePath);
+            if (Directory.Exists(cacheDirectoryPath)) {
+                Directory.Delete(cacheDirectoryPath, true);
+            }
         }
         private void InitSongPlayer() {
             songPlayer = new WasapiOut(playbackDevice, AudioClientShareMode.Shared, true, Audio.WASAPILatencyTarget);

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -169,11 +169,7 @@ namespace Edda {
                 colWaveformVertical,
                 imgWaveformVertical,
                 scrollSpectrogram,
-                imgSpectrogram,
-                rowSpectrogramLowerOffset,
-                rowSpectrogramUpperOffset,
-                canvasSpectrogramLowerOffset,
-                canvasSpectrogramUpperOffset,
+                panelSpectrogram,
                 EditorMarginGrid, 
                 canvasNavInputBox, 
                 canvasBookmarks, 
@@ -728,6 +724,10 @@ namespace Edda {
                 userSettings.SetValueForKey(UserSettingsKey.SpectrogramFlipped, DefaultUserSettings.SpectrogramFlipped);
             }
 
+            if (userSettings.GetValueForKey(UserSettingsKey.SpectrogramChunking) == null) {
+                userSettings.SetValueForKey(UserSettingsKey.SpectrogramChunking, DefaultUserSettings.SpectrogramChunking);
+            }
+
             if (userSettings.GetValueForKey(UserSettingsKey.EnableAutosave) == null) {
                 userSettings.SetValueForKey(UserSettingsKey.EnableAutosave, DefaultUserSettings.EnableAutosave);
             }
@@ -784,6 +784,12 @@ namespace Edda {
             gridController.spectrogramFrequency = spectrogramFrequency;
             gridController.spectrogramColormap = userSettings.GetValueForKey(UserSettingsKey.SpectrogramColormap);
             gridController.spectrogramFlipped = userSettings.GetBoolForKey(UserSettingsKey.SpectrogramFlipped);
+
+            var spectrogramChunking = gridController.spectrogramChunking;
+            gridController.spectrogramChunking = userSettings.GetBoolForKey(UserSettingsKey.SpectrogramChunking);
+            if (spectrogramChunking != gridController.spectrogramChunking) {
+                gridController.SetupSpectrogramContent();
+            }
             if (reloadWaveforms) {
                 gridController.RefreshSpectrogramWaveform();
                 gridController.DrawSpectrogram();

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -1,11 +1,11 @@
 ﻿<Window x:Class="Edda.SettingsWindow"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:Edda"
-        mc:Ignorable="d"
-        Title="Settings" Name="Window" Width="260" Height="520" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" Background="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}">
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="clr-namespace:Edda"
+    mc:Ignorable="d"
+    Title="Settings" Name="Window" Width="280" Height="560" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" Background="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}">
     <Grid>
         <DockPanel>
 
@@ -20,192 +20,257 @@
                     <Button x:Name="btnSave" Margin="0 10 10 10" Width="70" HorizontalAlignment="Right" Click="BtnSave_Click">OK</Button>
                 </StackPanel>
             </Border>
-            <StackPanel Margin="0 5 0 20" HorizontalAlignment="Center">
-                <Label Padding="10 5" FontWeight="Bold" FontSize="16" FontFamily="Bahnschrift">Editor</Label>
-                <Grid Margin="15 0 5 0" VerticalAlignment="Center">
-                    <Grid.Resources>
-                        <Style TargetType="Border" >
-                            <Setter Property="Padding" Value="5,5,5,5" />
-                        </Style>
-                    </Grid.Resources>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="110" />
-                        <ColumnDefinition Width="110" />
-                    </Grid.ColumnDefinitions>
+            <ScrollViewer VerticalScrollBarVisibility="Auto" FocusVisualStyle="{x:Null}">
+                <StackPanel Margin="0 5 0 20" HorizontalAlignment="Center">
+                    <Label Padding="10 5" FontWeight="Bold" FontSize="16" FontFamily="Bahnschrift">Editor</Label>
+                    <Grid Margin="15 0 5 0" VerticalAlignment="Center">
+                        <Grid.Resources>
+                            <Style TargetType="Border" >
+                                <Setter Property="Padding" Value="5,5,5,5" />
+                            </Style>
+                        </Grid.Resources>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="110" />
+                            <ColumnDefinition Width="110" />
+                        </Grid.ColumnDefinitions>
 
-                    <Border Grid.Row="0" Grid.Column="0">
-                        <TextBlock VerticalAlignment="Center">Autosave</TextBlock>
-                    </Border>
+                        <Border Grid.Row="0" Grid.Column="0">
+                            <TextBlock VerticalAlignment="Center">Autosave</TextBlock>
+                        </Border>
 
-                    <Border Grid.Row="0" Grid.Column="1">
-                        <CheckBox x:Name="CheckAutosave" Click="CheckAutosave_Click"/>
-                    </Border>
+                        <Border Grid.Row="0" Grid.Column="1">
+                            <CheckBox x:Name="CheckAutosave" Click="CheckAutosave_Click"/>
+                        </Border>
 
-                    <Border Grid.Row="1" Grid.Column="0">
-                        <TextBlock VerticalAlignment="Center">Show Spectrogram</TextBlock>
-                    </Border>
+                        <Border Grid.Row="1" Grid.Column="0">
+                            <TextBlock VerticalAlignment="Center">Show Spectrogram</TextBlock>
+                        </Border>
 
-                    <Border Grid.Row="1" Grid.Column="1">
-                        <CheckBox x:Name="CheckShowSpectrogram" Click="CheckShowSpectrogram_Click"/>
-                    </Border>
+                        <Border Grid.Row="1" Grid.Column="1">
+                            <CheckBox x:Name="CheckShowSpectrogram" Click="CheckShowSpectrogram_Click"/>
+                        </Border>
 
-                    <Border Grid.Row="2" Grid.Column="0">
-                        <TextBlock FontSize="10" VerticalAlignment="Center">Default Note Speed</TextBlock>
-                    </Border>
+                        <Border Grid.Row="2" Grid.Column="0">
+                            <TextBlock FontSize="10" VerticalAlignment="Center">Default Note Speed</TextBlock>
+                        </Border>
 
-                    <Border Grid.Row="2" Grid.Column="1">
-                        <StackPanel Orientation="Horizontal">
-                            <TextBox x:Name="txtDefaultNoteSpeed" Width="80" LostFocus="TxtDefaultNoteSpeed_LostFocus" VerticalAlignment="Center"/>
-                        </StackPanel>
-                    </Border>
+                        <Border Grid.Row="2" Grid.Column="1">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBox x:Name="txtDefaultNoteSpeed" Width="80" LostFocus="TxtDefaultNoteSpeed_LostFocus" VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Border>
 
-                </Grid>
-                <Label Margin="0 10 0 0" Padding="10 5" FontWeight="Bold" FontSize="16" FontFamily="Bahnschrift">Audio Playback</Label>
-                <Grid Margin="15 0 5 0" VerticalAlignment="Center">
-                    <Grid.Resources>
-                        <Style TargetType="Border" >
-                            <Setter Property="Padding" Value="5,5,5,5" />
-                        </Style>
-                    </Grid.Resources>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="110" />
-                        <ColumnDefinition Width="110" />
-                    </Grid.ColumnDefinitions>
+                    </Grid>
+                    <Label Margin="0 10 0 0" Padding="10 5" FontWeight="Bold" FontSize="16" FontFamily="Bahnschrift">Audio Playback</Label>
+                    <Grid Margin="15 0 5 0" VerticalAlignment="Center">
+                        <Grid.Resources>
+                            <Style TargetType="Border" >
+                                <Setter Property="Padding" Value="5,5,5,5" />
+                            </Style>
+                        </Grid.Resources>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="110" />
+                            <ColumnDefinition Width="110" />
+                        </Grid.ColumnDefinitions>
 
-                    <Border Grid.Row="0" Grid.Column="0">
-                        <TextBlock VerticalAlignment="Center">Output Device</TextBlock>
-                    </Border>
+                        <Border Grid.Row="0" Grid.Column="0">
+                            <TextBlock VerticalAlignment="Center">Output Device</TextBlock>
+                        </Border>
 
-                    <Border Grid.Row="0" Grid.Column="1">
-                        <ComboBox x:Name="comboPlaybackDevice" DisplayMemberPath="Name" SelectionChanged="ComboPlaybackDevice_SelectionChanged" VerticalAlignment="Center"/>
-                    </Border>
+                        <Border Grid.Row="0" Grid.Column="1">
+                            <ComboBox x:Name="comboPlaybackDevice" DisplayMemberPath="Name" SelectionChanged="ComboPlaybackDevice_SelectionChanged" VerticalAlignment="Center"/>
+                        </Border>
 
-                    <Border Grid.Row="1" Grid.Column="0">
-                        <TextBlock VerticalAlignment="Center">Audio Latency</TextBlock>
-                    </Border>
+                        <Border Grid.Row="1" Grid.Column="0">
+                            <TextBlock VerticalAlignment="Center">Audio Latency</TextBlock>
+                        </Border>
 
-                    <Border Grid.Row="1" Grid.Column="1">
-                        <StackPanel Orientation="Horizontal">
-                            <TextBox x:Name="txtAudioLatency" Width="80" LostFocus="TxtAudioLatency_LostFocus" VerticalAlignment="Center"/>
-                            <Label>ms</Label>
-                        </StackPanel>
-                    </Border>
+                        <Border Grid.Row="1" Grid.Column="1">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBox x:Name="txtAudioLatency" Width="80" LostFocus="TxtAudioLatency_LostFocus" VerticalAlignment="Center"/>
+                                <Label>ms</Label>
+                            </StackPanel>
+                        </Border>
 
-                    <Border Grid.Row="2" Grid.Column="0">
-                        <TextBlock VerticalAlignment="Center">Note Sound</TextBlock>
-                    </Border>
+                        <Border Grid.Row="2" Grid.Column="0">
+                            <TextBlock VerticalAlignment="Center">Note Sound</TextBlock>
+                        </Border>
 
-                    <Border Grid.Row="2" Grid.Column="1">
-                        <ComboBox x:Name="comboDrumSample" SelectionChanged="ComboDrumSample_SelectionChanged" VerticalAlignment="Center"/>
-                    </Border>
+                        <Border Grid.Row="2" Grid.Column="1">
+                            <ComboBox x:Name="comboDrumSample" SelectionChanged="ComboDrumSample_SelectionChanged" VerticalAlignment="Center"/>
+                        </Border>
 
-                    <Border Grid.Row="3" Grid.Column="0">
-                        <TextBlock VerticalAlignment="Center">Pan Note Sounds</TextBlock>
-                    </Border>
+                        <Border Grid.Row="3" Grid.Column="0">
+                            <TextBlock VerticalAlignment="Center">Pan Note Sounds</TextBlock>
+                        </Border>
 
-                    <Border Grid.Row="3" Grid.Column="1">
-                        <CheckBox x:Name="checkPanNotes" Click="checkPanNotes_Click"/>
-                    </Border>
+                        <Border Grid.Row="3" Grid.Column="1">
+                            <CheckBox x:Name="checkPanNotes" Click="checkPanNotes_Click"/>
+                        </Border>
 
-                    <Border Grid.Row="4" Grid.Column="0">
-                        <TextBlock FontSize="10.5"  VerticalAlignment="Center">Default Song Volume</TextBlock>
-                    </Border>
+                        <Border Grid.Row="4" Grid.Column="0">
+                            <TextBlock FontSize="10.5"  VerticalAlignment="Center">Default Song Volume</TextBlock>
+                        </Border>
 
-                    <Border Grid.Row="4" Grid.Column="1">
-                        <DockPanel>
-                            <TextBlock x:Name="txtSongVol" DockPanel.Dock="Right" Width="30" Margin="5 0 0 0">0%</TextBlock>
-                            <Slider x:Name="sliderSongVol" Maximum="1" ValueChanged="SliderSongVol_ValueChanged" IsMoveToPointEnabled="True" MouseLeftButtonUp="sliderSongVol_MouseLeftButtonUp" Thumb.DragCompleted="sliderSongVol_DragCompleted"/>
-                        </DockPanel>
-                    </Border>
+                        <Border Grid.Row="4" Grid.Column="1">
+                            <DockPanel>
+                                <TextBlock x:Name="txtSongVol" DockPanel.Dock="Right" Width="30" Margin="5 0 0 0">0%</TextBlock>
+                                <Slider x:Name="sliderSongVol" Maximum="1" ValueChanged="SliderSongVol_ValueChanged" IsMoveToPointEnabled="True" MouseLeftButtonUp="sliderSongVol_MouseLeftButtonUp" Thumb.DragCompleted="sliderSongVol_DragCompleted"/>
+                            </DockPanel>
+                        </Border>
 
-                    <Border Grid.Row="5" Grid.Column="0">
-                        <TextBlock FontSize="10.5" VerticalAlignment="Center">Default Note Volume</TextBlock>
-                    </Border>
+                        <Border Grid.Row="5" Grid.Column="0">
+                            <TextBlock FontSize="10.5" VerticalAlignment="Center">Default Note Volume</TextBlock>
+                        </Border>
 
-                    <Border Grid.Row="5" Grid.Column="1">
-                        <DockPanel>
-                            <TextBlock x:Name="txtDrumVol" DockPanel.Dock="Right" Width="30" Margin="5 0 0 0">0%</TextBlock>
-                            <Slider x:Name="sliderDrumVol" Maximum="1" ValueChanged="SliderDrumVol_ValueChanged" IsMoveToPointEnabled="True" MouseLeftButtonUp="sliderDrumVol_MouseLeftButtonUp" Thumb.DragCompleted="sliderDrumVol_DragCompleted"/>
-                        </DockPanel>
-                    </Border>
-                </Grid>
-                <Label Margin="0 10 0 0" Padding="10 5" FontWeight="Bold" FontSize="16" FontFamily="Bahnschrift">Miscellaneous</Label>
-                <Grid Margin="15 0 5 0" VerticalAlignment="Center">
-                    <Grid.Resources>
-                        <Style TargetType="Border" >
-                            <Setter Property="Padding" Value="5,5,5,5" />
-                        </Style>
-                    </Grid.Resources>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                        <RowDefinition Height="*" />
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="110" />
-                        <ColumnDefinition Width="110" />
-                    </Grid.ColumnDefinitions>
+                        <Border Grid.Row="5" Grid.Column="1">
+                            <DockPanel>
+                                <TextBlock x:Name="txtDrumVol" DockPanel.Dock="Right" Width="30" Margin="5 0 0 0">0%</TextBlock>
+                                <Slider x:Name="sliderDrumVol" Maximum="1" ValueChanged="SliderDrumVol_ValueChanged" IsMoveToPointEnabled="True" MouseLeftButtonUp="sliderDrumVol_MouseLeftButtonUp" Thumb.DragCompleted="sliderDrumVol_DragCompleted"/>
+                            </DockPanel>
+                        </Border>
+                    </Grid>
+                    <Label x:Name="spectrogramOptionsLabel" Margin="0 10 0 0" Padding="10 5" FontWeight="Bold" FontSize="16" FontFamily="Bahnschrift" Visibility="Collapsed">Spectrogram</Label>
+                    <Grid x:Name="spectrogramOptions" Margin="15 0 5 0" VerticalAlignment="Center" Visibility="Collapsed">
+                        <Grid.Resources>
+                            <Style TargetType="Border">
+                                <Setter Property="Padding" Value="5,5,5,5" />
+                            </Style>
+                        </Grid.Resources>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="110" />
+                            <ColumnDefinition Width="110" />
+                        </Grid.ColumnDefinitions>
 
-                    <Border Grid.Row="0" Grid.Column="0">
-                        <TextBlock VerticalAlignment="Center">Show in Discord</TextBlock>
-                    </Border>
+                        <Border Grid.Row="0" Grid.Column="0">
+                            <TextBlock VerticalAlignment="Center">Cache Images</TextBlock>
+                        </Border>
 
-                    <Border Grid.Row="0" Grid.Column="1">
-                        <CheckBox x:Name="checkDiscord" Click="CheckDiscord_Click"/>
-                    </Border>
+                        <Border Grid.Row="0" Grid.Column="1">
+                            <CheckBox x:Name="checkSpectrogramCache" Click="checkSpectrogramCache_Click" />
+                        </Border>
 
-                    <Border Grid.Row="1" Grid.Column="0">
-                        <TextBlock VerticalAlignment="Center">Check for Updates</TextBlock>
-                    </Border>
+                        <TextBlock Grid.Row="1" Grid.ColumnSpan="2" FontSize="8" VerticalAlignment="Center" TextWrapping="WrapWithOverflow">
+                            Faster spectrogram loading after it's been generated once. Warning:
+                            stores images in cache folder inside map directory, so make sure to
+                            exclude it from the ZIP if you're doing it outside of Edda.
+                        </TextBlock>
 
-                    <Border Grid.Row="1" Grid.Column="1">
-                        <CheckBox x:Name="checkStartupUpdate" Click="CheckStartupUpdate_Click"/>
-                    </Border>
+                        <Border Grid.Row="2" Grid.Column="0">
+                            <TextBlock VerticalAlignment="Center">Type</TextBlock>
+                        </Border>
 
-                    <Border Grid.Row="2" Grid.Column="0">
-                        <TextBlock VerticalAlignment="Center">Map Save Location</TextBlock>
-                    </Border>
+                        <Border Grid.Row="2" Grid.Column="1">
+                            <StackPanel Orientation="Horizontal">
+                                <ComboBox x:Name="comboSpectrogramType" SelectionChanged="ComboSpectrogramType_SelectionChanged"></ComboBox>
+                            </StackPanel>
+                        </Border>
 
-                    <Border Grid.Row="2" Grid.Column="1">
-                        <ComboBox x:Name="comboMapSaveFolder" VerticalAlignment="Center" SelectionChanged="comboMapSaveFolder_SelectionChanged">
-                            <ComboBoxItem x:Name="comboMapSaveFolder_Documents">Documents</ComboBoxItem>
-                            <ComboBoxItem x:Name="comboMapSaveFolder_GameInstall">Game Install</ComboBoxItem>
-                        </ComboBox>
-                    </Border>
+                        <Border Grid.Row="3" Grid.Column="0">
+                            <TextBlock VerticalAlignment="Center">Frequency</TextBlock>
+                        </Border>
 
-                    <Border Grid.Row="3" Grid.ColumnSpan="2" Padding="0">
-                        <TextBlock Width="210" FontSize="10" FontStyle="Italic" x:Name="txtMapSaveFolderPath" VerticalAlignment="Center" MouseLeftButtonUp="txtMapSaveFolderPath_MouseLeftButtonUp" Foreground="{DynamicResource {x:Static SystemColors.HotTrackBrushKey}}">C:/Username/Documents/Ragnarock/CustomSongs</TextBlock>
-                    </Border>
-                </Grid>
-            </StackPanel>
+                        <Border Grid.Row="3" Grid.Column="1">
+                            <StackPanel Orientation="Horizontal">
+                                <TextBox x:Name="txtSpectrogramFrequency" HorizontalAlignment="Left" Width="100" LostFocus="TxtSpectrogramFrequency_LostFocus" KeyDown="TxtSpectrogramFrequency_KeyDown" />
+                            </StackPanel>
+                        </Border>
+
+                        <Border Grid.Row="4" Grid.Column="0">
+                            <TextBlock VerticalAlignment="Center">Colormap</TextBlock>
+                        </Border>
+
+                        <Border Grid.Row="4" Grid.Column="1">
+                            <StackPanel Orientation="Horizontal">
+                                <ComboBox x:Name="comboSpectrogramColormap" SelectionChanged="ComboSpectrogramColormap_SelectionChanged"></ComboBox>
+                            </StackPanel>
+                        </Border>
+                    </Grid>
+                    <Label Margin="0 10 0 0" Padding="10 5" FontWeight="Bold" FontSize="16" FontFamily="Bahnschrift">Miscellaneous</Label>
+                    <Grid Margin="15 0 5 0" VerticalAlignment="Center">
+                        <Grid.Resources>
+                            <Style TargetType="Border" >
+                                <Setter Property="Padding" Value="5,5,5,5" />
+                            </Style>
+                        </Grid.Resources>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="110" />
+                            <ColumnDefinition Width="110" />
+                        </Grid.ColumnDefinitions>
+
+                        <Border Grid.Row="0" Grid.Column="0">
+                            <TextBlock VerticalAlignment="Center">Show in Discord</TextBlock>
+                        </Border>
+
+                        <Border Grid.Row="0" Grid.Column="1">
+                            <CheckBox x:Name="checkDiscord" Click="CheckDiscord_Click"/>
+                        </Border>
+
+                        <Border Grid.Row="1" Grid.Column="0">
+                            <TextBlock VerticalAlignment="Center">Check for Updates</TextBlock>
+                        </Border>
+
+                        <Border Grid.Row="1" Grid.Column="1">
+                            <CheckBox x:Name="checkStartupUpdate" Click="CheckStartupUpdate_Click"/>
+                        </Border>
+
+                        <Border Grid.Row="2" Grid.Column="0">
+                            <TextBlock VerticalAlignment="Center">Map Save Location</TextBlock>
+                        </Border>
+
+                        <Border Grid.Row="2" Grid.Column="1">
+                            <ComboBox x:Name="comboMapSaveFolder" VerticalAlignment="Center" SelectionChanged="comboMapSaveFolder_SelectionChanged">
+                                <ComboBoxItem x:Name="comboMapSaveFolder_Documents">Documents</ComboBoxItem>
+                                <ComboBoxItem x:Name="comboMapSaveFolder_GameInstall">Game Install</ComboBoxItem>
+                            </ComboBox>
+                        </Border>
+
+                        <Border Grid.Row="3" Grid.ColumnSpan="2" Padding="0">
+                            <TextBlock Width="210" FontSize="10" FontStyle="Italic" x:Name="txtMapSaveFolderPath" VerticalAlignment="Center" MouseLeftButtonUp="txtMapSaveFolderPath_MouseLeftButtonUp" Foreground="{DynamicResource {x:Static SystemColors.HotTrackBrushKey}}">C:/Username/Documents/Ragnarock/CustomSongs</TextBlock>
+                        </Border>
+                    </Grid>
+                </StackPanel>
+            </ScrollViewer>
         </DockPanel>
     </Grid>
 </Window>

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -167,6 +167,7 @@
                             <RowDefinition Height="*" />
                             <RowDefinition Height="*" />
                             <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="110" />
@@ -233,6 +234,14 @@
 
                         <Border Grid.Row="6" Grid.Column="1">
                             <CheckBox x:Name="checkSpectrogramFlipped" Click="checkSpectrogramFlipped_Click" />
+                        </Border>
+
+                        <Border Grid.Row="7" Grid.Column="0">
+                            <TextBlock VerticalAlignment="Center">Enable Chunking</TextBlock>
+                        </Border>
+
+                        <Border Grid.Row="7" Grid.Column="1">
+                            <CheckBox x:Name="checkSpectrogramChunking" Click="checkSpectrogramChunking_Click" />
                         </Border>
                     </Grid>
                     <Label Margin="0 10 0 0" Padding="10 5" FontWeight="Bold" FontSize="16" FontFamily="Bahnschrift">Miscellaneous</Label>

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -166,6 +166,7 @@
                             <RowDefinition Height="*" />
                             <RowDefinition Height="*" />
                             <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="110" />
@@ -197,30 +198,40 @@
                         </Border>
 
                         <Border Grid.Row="3" Grid.Column="0">
-                            <TextBlock VerticalAlignment="Center">Frequency</TextBlock>
+                            <TextBlock VerticalAlignment="Center">Quality</TextBlock>
                         </Border>
 
                         <Border Grid.Row="3" Grid.Column="1">
+                            <StackPanel Orientation="Horizontal">
+                                <ComboBox x:Name="comboSpectrogramQuality" SelectionChanged="ComboSpectrogramQuality_SelectionChanged"></ComboBox>
+                            </StackPanel>
+                        </Border>
+
+                        <Border Grid.Row="4" Grid.Column="0">
+                            <TextBlock VerticalAlignment="Center">Frequency</TextBlock>
+                        </Border>
+
+                        <Border Grid.Row="4" Grid.Column="1">
                             <StackPanel Orientation="Horizontal">
                                 <TextBox x:Name="txtSpectrogramFrequency" HorizontalAlignment="Left" Width="100" LostFocus="TxtSpectrogramFrequency_LostFocus" KeyDown="TxtSpectrogramFrequency_KeyDown" />
                             </StackPanel>
                         </Border>
 
-                        <Border Grid.Row="4" Grid.Column="0">
+                        <Border Grid.Row="5" Grid.Column="0">
                             <TextBlock VerticalAlignment="Center">Colormap</TextBlock>
                         </Border>
 
-                        <Border Grid.Row="4" Grid.Column="1">
+                        <Border Grid.Row="5" Grid.Column="1">
                             <StackPanel Orientation="Horizontal">
                                 <ComboBox x:Name="comboSpectrogramColormap" SelectionChanged="ComboSpectrogramColormap_SelectionChanged"></ComboBox>
                             </StackPanel>
                         </Border>
 
-                        <Border Grid.Row="5" Grid.Column="0">
+                        <Border Grid.Row="6" Grid.Column="0">
                             <TextBlock VerticalAlignment="Center">Flip Image</TextBlock>
                         </Border>
 
-                        <Border Grid.Row="5" Grid.Column="1">
+                        <Border Grid.Row="6" Grid.Column="1">
                             <CheckBox x:Name="checkSpectrogramFlipped" Click="checkSpectrogramFlipped_Click" />
                         </Border>
                     </Grid>

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -165,6 +165,7 @@
                             <RowDefinition Height="*" />
                             <RowDefinition Height="*" />
                             <RowDefinition Height="*" />
+                            <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="110" />
@@ -213,6 +214,14 @@
                             <StackPanel Orientation="Horizontal">
                                 <ComboBox x:Name="comboSpectrogramColormap" SelectionChanged="ComboSpectrogramColormap_SelectionChanged"></ComboBox>
                             </StackPanel>
+                        </Border>
+
+                        <Border Grid.Row="5" Grid.Column="0">
+                            <TextBlock VerticalAlignment="Center">Flip Image</TextBlock>
+                        </Border>
+
+                        <Border Grid.Row="5" Grid.Column="1">
+                            <CheckBox x:Name="checkSpectrogramFlipped" Click="checkSpectrogramFlipped_Click" />
                         </Border>
                     </Grid>
                     <Label Margin="0 10 0 0" Padding="10 5" FontWeight="Bold" FontSize="16" FontFamily="Bahnschrift">Miscellaneous</Label>

--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -43,6 +43,7 @@ namespace Edda
             CheckShowSpectrogram.IsChecked = userSettings.GetBoolForKey(UserSettingsKey.EnableSpectrogram);
             ToggleSpectrogramOptionsVisibility();
             InitComboSpectrogramType();
+            InitComboSpectrogramQuality();
             InitComboSpectrogramColormap();
             checkSpectrogramCache.IsChecked = userSettings.GetBoolForKey(UserSettingsKey.SpectrogramCache);
             txtSpectrogramFrequency.Text = userSettings.GetValueForKey(UserSettingsKey.SpectrogramFrequency);
@@ -195,6 +196,21 @@ namespace Edda
                 int i = comboSpectrogramType.Items.Add(type);
                 if (type == selectedSpectrogramType) {
                     comboSpectrogramType.SelectedIndex = i;
+                }
+            }
+        }
+        private void ComboSpectrogramQuality_SelectionChanged(object sender, SelectionChangedEventArgs e) {
+            userSettings.SetValueForKey(UserSettingsKey.SpectrogramQuality, comboSpectrogramQuality.SelectedItem.ToString());
+            if (doneInit) {
+                UpdateSettings();
+            }
+        }
+        private void InitComboSpectrogramQuality() {
+            string selectedSpectrogramQuality = userSettings.GetValueForKey(UserSettingsKey.SpectrogramQuality);
+            foreach (var quality in Enum.GetNames(typeof(VorbisSpectrogramGenerator.SpectrogramQuality))) {
+                int i = comboSpectrogramQuality.Items.Add(quality);
+                if (quality == selectedSpectrogramQuality) {
+                    comboSpectrogramQuality.SelectedIndex = i;
                 }
             }
         }

--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -231,6 +231,13 @@ namespace Edda
                 }
             }
         }
+        private void checkSpectrogramFlipped_Click(object sender, RoutedEventArgs e) {
+            bool newStatus = checkSpectrogramFlipped.IsChecked ?? false;
+            userSettings.SetValueForKey(UserSettingsKey.SpectrogramFlipped, newStatus);
+            if (doneInit) {
+                UpdateSettings();
+            }
+        }
         
         private void CheckDiscord_Click(object sender, RoutedEventArgs e) {
             bool newStatus = checkDiscord.IsChecked ?? false;

--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -46,6 +46,7 @@ namespace Edda
             InitComboSpectrogramColormap();
             checkSpectrogramCache.IsChecked = userSettings.GetBoolForKey(UserSettingsKey.SpectrogramCache);
             txtSpectrogramFrequency.Text = userSettings.GetValueForKey(UserSettingsKey.SpectrogramFrequency);
+            checkSpectrogramFlipped.IsChecked = userSettings.GetBoolForKey(UserSettingsKey.SpectrogramFlipped);
             checkStartupUpdate.IsChecked = userSettings.GetBoolForKey(UserSettingsKey.CheckForUpdates);
             comboMapSaveFolder.SelectedIndex = int.Parse(userSettings.GetValueForKey(UserSettingsKey.MapSaveLocationIndex));
             txtMapSaveFolderPath.Text = (comboMapSaveFolder.SelectedIndex == 0) ? Program.DocumentsMapFolder : userSettings.GetValueForKey(UserSettingsKey.MapSaveLocationPath);

--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -48,6 +48,7 @@ namespace Edda
             checkSpectrogramCache.IsChecked = userSettings.GetBoolForKey(UserSettingsKey.SpectrogramCache);
             txtSpectrogramFrequency.Text = userSettings.GetValueForKey(UserSettingsKey.SpectrogramFrequency);
             checkSpectrogramFlipped.IsChecked = userSettings.GetBoolForKey(UserSettingsKey.SpectrogramFlipped);
+            checkSpectrogramChunking.IsChecked = userSettings.GetBoolForKey(UserSettingsKey.SpectrogramChunking);
             checkStartupUpdate.IsChecked = userSettings.GetBoolForKey(UserSettingsKey.CheckForUpdates);
             comboMapSaveFolder.SelectedIndex = int.Parse(userSettings.GetValueForKey(UserSettingsKey.MapSaveLocationIndex));
             txtMapSaveFolderPath.Text = (comboMapSaveFolder.SelectedIndex == 0) ? Program.DocumentsMapFolder : userSettings.GetValueForKey(UserSettingsKey.MapSaveLocationPath);
@@ -251,6 +252,14 @@ namespace Edda
         private void checkSpectrogramFlipped_Click(object sender, RoutedEventArgs e) {
             bool newStatus = checkSpectrogramFlipped.IsChecked ?? false;
             userSettings.SetValueForKey(UserSettingsKey.SpectrogramFlipped, newStatus);
+            if (doneInit) {
+                UpdateSettings();
+            }
+        }
+
+        private void checkSpectrogramChunking_Click(object sender, RoutedEventArgs e) {
+            bool newStatus = checkSpectrogramChunking.IsChecked ?? false;
+            userSettings.SetValueForKey(UserSettingsKey.SpectrogramChunking, newStatus);
             if (doneInit) {
                 UpdateSettings();
             }


### PR DESCRIPTION
#24

Added a way to resize the column with spectrogram to get both a better look at the image and to allow users to drag it closer to the note editor to check their alignment.

Added caching for spectrogram to make sure we don't re-do expensive calculations unnecessarily when opening a map again or resizing the spectrogram.

Added user settings for customizing the spectrogram, including algorithm used, frequency range and colormap (previously it was always MelScale, 16kHZ, Blues). I've set the defaults to Standard, 11kHz, which seems about the same settings that are used by MMA2 for their spectrogram. I've left Blues as the default colormap for theming, but after testing a few I actually found I prefer Lopora more and I saw that MMA2 uses Plasma.

![image](https://user-images.githubusercontent.com/12004018/224448233-38b49749-99cc-4c4b-bcbd-b2c7e380f2c7.png)

White bar allows user to change the width of the spectrogram by dragging it:
![image](https://user-images.githubusercontent.com/12004018/224448307-c1f98756-f3f3-4581-bcd8-eb17153dcc31.png)

New section in user settings (only displays after user enables spectrogram):
![image](https://user-images.githubusercontent.com/12004018/224834725-f371ef9e-0e51-4f97-b6c5-cf5a6398e0d4.png)

Using Standard with 11kHz takes a little longer to load initially, but provides much higher resolution, especially with the ability to resize:
![image](https://user-images.githubusercontent.com/12004018/224835291-5612e4d4-b031-4f31-9cb0-6a79b25a00db.png)


