### PR TITLE
Change "Beat Division" depending on mouse position

### DIFF
--- a/Windows/MainWindow.UIControls.cs
+++ b/Windows/MainWindow.UIControls.cs
@@ -283,16 +283,14 @@ namespace Edda {
                 int.TryParse(txtGridDivision.Text, out currentBeatDivision);
                 txtGridDivision.Text = ((int)Helper.DoubleRangeTruncate(currentBeatDivision + delta, 1, Editor.GridDivisionMax)).ToString();
             } else {    
-                // Update the BPM value in the original list
-                foreach ( BPMChange bpmChange in mapEditor.currentMapDifficulty.bpmChanges.OrderByDescending(bpmChange => bpmChange.globalBeat)) {
-                    if (bpmChange.globalBeat < pos)
-                    {
-                        bpmChange.gridDivision = (int)Helper.DoubleRangeTruncate(bpmChange.gridDivision + delta, 1, Editor.GridDivisionMax);
-                        
-                        // Redraw grid
-                        gridController.DrawGrid(false);
-                        break;
-                    }
+                var currentBpmChange = mapEditor.currentMapDifficulty.bpmChanges
+                    .Where(bpmChange => bpmChange.globalBeat < pos)
+                    .OrderByDescending(bpmChange => bpmChange.globalBeat)
+                    .FirstOrDefault();
+
+                if (currentBpmChange != null) {
+                    currentBpmChange.gridDivision = (int) Helper.DoubleRangeTruncate(currentBpmChange.gridDivision + delta, 1, Editor.GridDivisionMax);
+                    gridController.DrawGrid(false);
                 }
             }
             e.Handled = true; // Mark tunneling event as handled to prevent scrolling on the grid while changing the division.


### PR DESCRIPTION
This change allows to use `Ctrl` + `MouseWheel` to change the grid of the last BpmChange depending on the mouse position:

![image](https://github.com/PKBeam/Edda/assets/91031776/53c43195-3f97-4708-b723-33b0b3623541)
