### PR TITLE
Bug: Edda will not attempt to change cover image when the cover image is already set

### DIFF
--- a/Classes/Helper.cs
+++ b/Classes/Helper.cs
@@ -2,14 +2,13 @@
 using Microsoft.WindowsAPICodePack.Dialogs;
 using Newtonsoft.Json.Linq;
 using System;
-using System.CodeDom;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Numerics;
+using System.Net.Cache;
 using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Media.Imaging;
@@ -334,11 +333,18 @@ public class Helper {
     public static string NameGenerator(Note n) {
         return "N" + n.GetHashCode().ToString();
     }
-    public static BitmapImage BitmapGenerator(Uri u) {
+    public static BitmapImage BitmapGenerator(Uri u, bool ignoreCache = false) {
         var b = new BitmapImage();
         b.BeginInit();
-        b.UriSource = u;
+        if (ignoreCache) {
+            b.CacheOption = BitmapCacheOption.None;
+            b.UriCachePolicy = new RequestCachePolicy(RequestCacheLevel.BypassCache);
+        }
         b.CacheOption = BitmapCacheOption.OnLoad;
+        if (ignoreCache) {
+            b.CreateOptions = BitmapCreateOptions.IgnoreImageCache;
+        }
+        b.UriSource = u;
         b.EndInit();
         b.Freeze();
         return b;

--- a/Classes/MapConverters/StepManiaMapConverter.cs
+++ b/Classes/MapConverters/StepManiaMapConverter.cs
@@ -192,11 +192,7 @@ public class StepManiaMapConverter : IMapConverter
         {
             string newCoverFilename = Helper.SanitiseCoverFileName(coverImageFilename);
             string newCoverUrl = beatmap.PathOf(newCoverFilename);
-            // can't copy over an existing file
-            if (File.Exists(newCoverUrl))
-            {
-                File.Delete(newCoverUrl);
-            }
+            Helper.FileDeleteIfExists(newCoverUrl);
             File.Copy(Path.Combine(smFile.Directory, coverImageFilename), newCoverUrl);
             beatmap.SetValue("_coverImageFilename", newCoverFilename);
         }

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -818,17 +818,14 @@ namespace Edda {
             string newFile = Helper.SanitiseCoverFileName(d.FileName);
             string newPath = Path.Combine(mapEditor.mapFolder, newFile);
 
-            // load new cover image, if necessary
-            if (prevPath != newPath) {
+            // skip only when the chosen file is already the map cover file
+            if (prevPath != d.FileName) {
                 // remove the previous cover image
                 Helper.FileDeleteIfExists(prevPath);
-                // copy over the image file if it's not in the same folder already
-                if (!d.FileName.StartsWith(mapEditor.mapFolder)) {
-                    // delete any existing files in the map folder with conflicting names
-                    Helper.FileDeleteIfExists(newPath);
-                    // copy image file over
-                    File.Copy(d.FileName, newPath);
-                }
+                // delete any existing files in the map folder with conflicting names
+                Helper.FileDeleteIfExists(newPath);
+                // copy image file over
+                File.Copy(d.FileName, newPath);
 
                 mapEditor.SetMapValue("_coverImageFilename", newFile);
                 SaveBeatmap();
@@ -840,7 +837,8 @@ namespace Edda {
             if (fileName == "") {
                 ClearCoverImage();
             } else {
-                BitmapImage b = Helper.BitmapGenerator(new Uri(Path.Combine(mapEditor.mapFolder, fileName)));
+                // Need to ignore cache, since we replace the contents of the cover.* file.
+                BitmapImage b = Helper.BitmapGenerator(new Uri(Path.Combine(mapEditor.mapFolder, fileName)), true);
                 imgCover.Source = b;
                 txtCoverFileName.Text = fileName;
                 borderImgCover.BorderThickness = new(2);


### PR DESCRIPTION
#50 Fixed an issue that blocked users from replacing existing cover imageon maps after the recent changes to the cover filename convention.