### PR TITLE
ffmpeg-temp.exe should not be deleted once created, instead it should be overwritten or left alone

### DIFF
--- a/Classes/Helper.cs
+++ b/Classes/Helper.cs
@@ -190,27 +190,24 @@ public class Helper {
             Trace.WriteLine(message);
         })).Start();
     }
-    public static void FFmpeg(string dir, string arg) {
+    public static int FFmpeg(string dir, string arg) {
         // uses a custom-built version of ffmpeg with ONLY libvorbis support
         // (cuts down on filesize a lot)
-        string path = Path.Combine(Path.GetTempPath(), "ffmpeg_temp.exe");
+        string path = Path.Combine(Path.GetTempPath(), $"ffmpeg_temp_{Process.GetCurrentProcess().Id}.exe");
         File.WriteAllBytes(path, Edda.Properties.Resources.ffmpeg);
 
         var p = Process.Start(path, arg);
-        //p.StartInfo.RedirectStandardOutput = true;
-        //p.StartInfo.RedirectStandardError = true;
-        //p.Start();
-        //var output = p.StandardOutput.ReadToEnd();
-        //var err = p.StandardError.ReadToEnd();
-        //File.WriteAllText(dir + "/out.txt", err);
-        //File.WriteAllText(dir + "/err.txt", err);
         p.WaitForExit();
+        int exitCode = p.ExitCode;
+        p.Close(); // To free up the handle on ffmpeg_temp_{pid}.exe
 
-        try {
+        try {           
             File.Delete(path);
         } catch (Exception e) {
-            MessageBox.Show($"Couldn't delete file at {path}. {e}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            Trace.WriteLine($"WARNING: Failed to delete {path}: ({e})");
         }
+
+        return exitCode;
     }
     public static void CmdCopyFile(string src, string dst) {
         var p = Process.Start("cmd.exe", "/C copy \"" + src + "\" \"" + dst + "\"");

--- a/Classes/MapConverters/StepManiaMapConverter.cs
+++ b/Classes/MapConverters/StepManiaMapConverter.cs
@@ -218,7 +218,11 @@ public class StepManiaMapConverter : IMapConverter
             int startSec = (int)(sampleStart - 60 * startMin);
             int endMin = (int)((sampleStart + sampleLength) / 60);
             int endSec = (int)(sampleStart + sampleLength - 60 * endMin);
-            Helper.FFmpeg(beatmap.PathOf(""), $"-i \"{songURL}\" -y -ss 00:{startMin:D2}:{startSec:D2} -to 00:{endMin:D2}:{endSec:D2} -vn \"{saveURL}\"");
+            int exitCode = Helper.FFmpeg(beatmap.PathOf(""), $"-i \"{songURL}\" -y -ss 00:{startMin:D2}:{startSec:D2} -to 00:{endMin:D2}:{endSec:D2} -vn \"{saveURL}\"");
+            if (exitCode != 0)
+            {
+                System.Diagnostics.Trace.WriteLine($"WARNING: Failed to generate preview.ogg");
+            }
         }
     }
 

--- a/Windows/MainWindow.UIControls.cs
+++ b/Windows/MainWindow.UIControls.cs
@@ -56,6 +56,8 @@ namespace Edda {
             oldMetronome?.Dispose();
             Trace.WriteLine("INFO: Audio resources disposed...");
 
+            Helper.FileDeleteIfExists(Path.Combine(Path.GetTempPath(), $"ffmpeg_temp_{Process.GetCurrentProcess().Id}.exe"));
+
             // TODO find other stuff to dispose so we don't cause a memory leak
             // Application.Current.Shutdown();
         }

--- a/Windows/SongPreviewWindow.xaml.cs
+++ b/Windows/SongPreviewWindow.xaml.cs
@@ -139,9 +139,14 @@ namespace Edda
             if (TimeRangeDurationCheck() || ShowDurationError()) {
                 string saveURL = Path.Combine(songFolder, "preview.ogg");
                 btnGenerate.IsEnabled = false;
-                Helper.FFmpeg(songFolder, $"-i \"{songURL}\" -y -ss 00:{startMin:D2}:{startSec:D2} -to 00:{endMin:D2}:{endSec:D2} -vn -af afade=t=out:st={TotalSec(endMin, endSec) - fadeOutDur}:d={fadeOutDur},afade=t=in:st={TotalSec(startMin, startSec)}:d={fadeInDur} \"{saveURL}\"");
+                int exitCode = Helper.FFmpeg(songFolder, $"-i \"{songURL}\" -y -ss 00:{startMin:D2}:{startSec:D2} -to 00:{endMin:D2}:{endSec:D2} -vn -af afade=t=out:st={TotalSec(endMin, endSec) - fadeOutDur}:d={fadeOutDur},afade=t=in:st={TotalSec(startMin, startSec)}:d={fadeInDur} \"{saveURL}\"");
                 btnGenerate.IsEnabled = true;
-                MessageBox.Show($"Song preview created successfully.", "Success", MessageBoxButton.OK, MessageBoxImage.Information);
+                if (exitCode == 0) {
+                    MessageBox.Show($"Song preview created successfully.", "Success", MessageBoxButton.OK, MessageBoxImage.Information);
+                } else {
+                    MessageBox.Show($"There was an issue creating song preview.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                }
+                
             }
         }
 


### PR DESCRIPTION
#48 
Refactored Helper.FFmpeg to avoid running into issues when accessing or deleting the temporary file.

Tested with multiple Edda instances generating song previews at the same time and didn't run into any issues.