### PR TITLE
Potential data corruption/deletion bug while creating new difficulty

### DIFF
--- a/Classes/Audio/AudioScanner.cs
+++ b/Classes/Audio/AudioScanner.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Edda.Const;
 
-public class AudioScanner {
+public class AudioScanner : IDisposable {
     int scanIndex;
     double tempo;
     protected int stopwatchOffset = 0;
@@ -25,6 +25,19 @@ public class AudioScanner {
     }
 
     public AudioScanner(ParallelAudioPlayer parallelAudioPlayer) : this(parallelAudioPlayer, 1.0) {
+    }
+
+    public virtual void Dispose()
+    {
+        stopwatch?.Stop();
+        stopwatch = null;
+
+        tokenSource?.Cancel();
+        tokenSource?.Dispose();
+        tokenSource = null;
+
+        notes = null;
+        parallelAudioPlayer = null;
     }
 
     public void SetTempo(double newTempo) {

--- a/Classes/Audio/DeviceChangeListener.cs
+++ b/Classes/Audio/DeviceChangeListener.cs
@@ -1,16 +1,22 @@
 using NAudio.CoreAudioApi;
 using NAudio.CoreAudioApi.Interfaces;
+using System;
 using System.Windows;
 
 namespace Edda
 {
-    public class DeviceChangeListener : IMMNotificationClient
+    public class DeviceChangeListener : IMMNotificationClient, IDisposable
     {
         MainWindow caller;
 
         public DeviceChangeListener(MainWindow caller)
         {
             this.caller = caller;
+        }
+
+        public void Dispose()
+        {
+            this.caller = null;
         }
 
         public void OnDefaultDeviceChanged(DataFlow flow, Role role, string defaultDeviceId)

--- a/Classes/Audio/NoteScanner.cs
+++ b/Classes/Audio/NoteScanner.cs
@@ -13,6 +13,14 @@ public class NoteScanner: AudioScanner {
         this.caller = caller;
         this.playedLateNote = false;
     }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        caller = null;
+        notesPlayed = null;
+    }
+
     protected override void OnNoteScanBegin() {
         notesPlayed = new List<Note>();
     }

--- a/Classes/Audio/ParallelAudioPlayer.cs
+++ b/Classes/Audio/ParallelAudioPlayer.cs
@@ -104,6 +104,9 @@ public class ParallelAudioPlayer: IDisposable {
             noteStreams[i].Dispose();
             notePlayers[i].Dispose();
         }
+        noteStreams = null;
+        notePlayers = null;
+        playbackDevice = null;
     }
     private string GetFilePath(string basePath, int sampleNumber) {
         return $"{Program.ResourcesPath}{basePath}{sampleNumber}.wav";

--- a/Classes/Audio/VorbisWaveformGenerator.cs
+++ b/Classes/Audio/VorbisWaveformGenerator.cs
@@ -10,7 +10,7 @@ using System.IO;
 using System.Threading;
 using Edda.Const;
 
-public class VorbisWaveformGenerator {
+public class VorbisWaveformGenerator : IDisposable {
 
 	private CancellationTokenSource tokenSource;
 	private string filePath;
@@ -20,7 +20,14 @@ public class VorbisWaveformGenerator {
 		this.filePath = filePath;
 		this.isDrawing = false;
 	}
-	public ImageSource Draw(double height, double width) {
+
+    public void Dispose()
+    {
+		tokenSource?.Cancel();
+		tokenSource = null;
+    }
+
+    public ImageSource Draw(double height, double width) {
 		tokenSource.Cancel();
 		while (isDrawing) {
 			Thread.Sleep(100);
@@ -141,62 +148,62 @@ public class VorbisWaveformGenerator {
 		}
 		tokenSource = new CancellationTokenSource();
 	}
-	/* 
-	 public ImageSource DrawLarge(double height, double width) {
-		var largest = Math.Max(height, width);
-		if (largest > Const.Editor.Waveform.MaxDimension) {
-			double scale = Const.Editor.Waveform.MaxDimension / largest;
-			height *= scale;
-			width *= scale;
-		}
-		var bitmap = new WriteableBitmap((int)width, (int)height, 96, 96, PixelFormats.Pbgra32, null);
+    /* 
+ public ImageSource DrawLarge(double height, double width) {
+    var largest = Math.Max(height, width);
+    if (largest > Const.Editor.Waveform.MaxDimension) {
+        double scale = Const.Editor.Waveform.MaxDimension / largest;
+        height *= scale;
+        width *= scale;
+    }
+    var bitmap = new WriteableBitmap((int)width, (int)height, 96, 96, PixelFormats.Pbgra32, null);
 
-		isDrawing = true;
-		VorbisWaveReader reader = new(filePath);
-		reader.Position = 0;
+    isDrawing = true;
+    VorbisWaveReader reader = new(filePath);
+    reader.Position = 0;
 
-		int channels = reader.WaveFormat.Channels;
-		var bytesPerSample = reader.WaveFormat.BitsPerSample / 8 * channels;
-		var numSamples = reader.Length / bytesPerSample;
+    int channels = reader.WaveFormat.Channels;
+    var bytesPerSample = reader.WaveFormat.BitsPerSample / 8 * channels;
+    var numSamples = reader.Length / bytesPerSample;
 
-		int samplesPerPixel = (int)(numSamples / height) * channels;
-		double samplesPerPixel_d = numSamples / height * channels;
-		int totalSamples = 0;
-		double totalSamples_d = 0;
+    int samplesPerPixel = (int)(numSamples / height) * channels;
+    double samplesPerPixel_d = numSamples / height * channels;
+    int totalSamples = 0;
+    double totalSamples_d = 0;
 
-		var buffer = new float[samplesPerPixel + channels];
-		for (int pixel = 0; pixel < height; pixel++) {
+    var buffer = new float[samplesPerPixel + channels];
+    for (int pixel = 0; pixel < height; pixel++) {
 
-			// read samples
-			int samplesRead = reader.Read(buffer, 0, samplesPerPixel);
-			if (samplesRead == 0) {
-				break;
-			}
+        // read samples
+        int samplesRead = reader.Read(buffer, 0, samplesPerPixel);
+        if (samplesRead == 0) {
+            break;
+        }
 
-			// correct floating point rounding errors
-			totalSamples += samplesPerPixel;
-			totalSamples_d += samplesPerPixel_d;
-			if (totalSamples_d - totalSamples > channels) {
-				totalSamples += channels;
-				reader.Read(buffer, samplesPerPixel, channels);
-			}
+        // correct floating point rounding errors
+        totalSamples += samplesPerPixel;
+        totalSamples_d += samplesPerPixel_d;
+        if (totalSamples_d - totalSamples > channels) {
+            totalSamples += channels;
+            reader.Read(buffer, samplesPerPixel, channels);
+        }
 
-			var samples = new List<float>(buffer);
-			samples.Sort();
-			float lowPercent = (samples[(int)((samples.Count - 1) * (1 - Const.Editor.Waveform.SampleMaxPercentile))] + 1) / 2;
-			float highPercent = (samples[(int)((samples.Count - 1) * Const.Editor.Waveform.SampleMaxPercentile)] + 1) / 2;
-			float lowValue = (float)width * lowPercent;
-			float highValue = (float)width * highPercent;
+        var samples = new List<float>(buffer);
+        samples.Sort();
+        float lowPercent = (samples[(int)((samples.Count - 1) * (1 - Const.Editor.Waveform.SampleMaxPercentile))] + 1) / 2;
+        float highPercent = (samples[(int)((samples.Count - 1) * Const.Editor.Waveform.SampleMaxPercentile)] + 1) / 2;
+        float lowValue = (float)width * lowPercent;
+        float highValue = (float)width * highPercent;
 
-		    bitmap.DrawLine((int)lowValue, (int)(height - pixel), (int)highValue, (int)(height - pixel), Const.Editor.Waveform.ColourWPF);
-		}
+        bitmap.DrawLine((int)lowValue, (int)(height - pixel), (int)highValue, (int)(height - pixel), Const.Editor.Waveform.ColourWPF);
+    }
 
-		//RenderTargetToDisk(bmp);
-		isDrawing = false;
-		return RenderTargetToImage(bitmap);
-	}
-	 */
-	/*
+    //RenderTargetToDisk(bmp);
+    isDrawing = false;
+    return RenderTargetToImage(bitmap);
+}
+ */
+    /*
 	public void DrawToCanvas(double height, double width, System.Windows.Controls.Canvas canvas) {
 		VorbisWaveReader reader = new(filePath);
 		reader.Position = 0;

--- a/Classes/EddaConstants.cs
+++ b/Classes/EddaConstants.cs
@@ -173,6 +173,7 @@ namespace Edda.Const {
             public const int DefaultFreq = 11_000; // Hz
             public const int FftSizeExp = 11; // FFT Size = 2^FftSizeExp
             public const int StepSize = 500; // samples
+            public const int MaxSampleSteps = 65500; // we can handle roughly this many steps through samples before we reach the max pixel size of the bitmap for a chunk.
             public const int NumberOfChunks = 12; // Each chunk can span roughly 5 minutes before we reach the max pixel size of the bitmap.
             public const string CachedBmpFilenameFormat = "spectrogram_{0}_{1}_{2}_{3}_*.png";
         }

--- a/Classes/MapEditor/MapEditor.cs
+++ b/Classes/MapEditor/MapEditor.cs
@@ -49,7 +49,7 @@ public enum MoveNote {
     MOVE_GRID_DOWN
 }
 
-public class MapEditor {
+public class MapEditor : IDisposable {
     public string mapFolder;
     RagnarockMap beatMap;
     MainWindow parent;
@@ -99,6 +99,15 @@ public class MapEditor {
         }
         this.clipboard = new();
     }
+
+    public void Dispose()
+    {
+        beatMap = null;
+        parent = null;
+        difficultyMaps = null;
+        clipboard = null;
+    }
+
     public MapDifficulty? GetDifficulty(int indx) {
         return difficultyMaps[indx];
     }

--- a/Classes/UI/EditorGridController.cs
+++ b/Classes/UI/EditorGridController.cs
@@ -18,7 +18,7 @@ using MediaColor = System.Windows.Media.Color;
 using DrawingColor = System.Drawing.Color;
 using Edda.Const;
 
-public class EditorGridController {
+public class EditorGridController: IDisposable {
 
     MapEditor mapEditor;
 
@@ -231,6 +231,58 @@ public class EditorGridController {
         lineGridMouseover.Visibility = Visibility.Hidden;
         EditorGrid.Children.Add(lineGridMouseover);
     }
+
+    public void Dispose()
+    {
+        // Clear the most memory-heavy components
+        noteCanvas.Children.Clear();
+        EditorGrid.Children.Clear();
+        panelSpectrogram.Children.Clear();
+        imgWaveformVertical.Source = null;
+        imgAudioWaveform.Source = null;
+        foreach (var imgSpectorgramChunk in imgSpectrogramChunks)
+        {
+            imgSpectorgramChunk.Source = null;
+        }
+
+        // Unbind references
+        mapEditor = null;
+        parentWindow = null;
+        EditorGrid = null;
+        scrollEditor = null;
+        referenceCol = null;
+        referenceRow = null;
+        borderNavWaveform = null;
+        colWaveformVertical = null;
+        imgWaveformVertical = null;
+        scrollSpectrogram = null;
+        panelSpectrogram = null;
+        canvasSpectrogramLowerOffset = null;
+        canvasSpectrogramUpperOffset = null;
+        imgSpectrogramChunks = null;
+        editorMarginGrid = null;
+        canvasNavInputBox = null;
+        canvasBookmarks = null;
+        canvasBookmarkLabels = null;
+        lineSongMouseover = null;
+        dispatcher = null;
+        dragSelectBorder = null;
+        lineGridMouseover = null;
+        noteCanvas = null;
+        imgAudioWaveform = null;
+        imgPreviewNote = null;
+
+        audioSpectrogram?.Dispose();
+        audioSpectrogram = null;
+        audioWaveform?.Dispose();
+        audioWaveform = null;
+        navWaveform?.Dispose();
+        navWaveform = null;
+
+        currentlyDraggingMarker = null;
+        currentlyDraggingBookmark = null;
+        currentlyDraggingBPMChange = null;
+}
 
     public void InitMap(MapEditor me) {
         this.mapEditor = me;

--- a/Windows/MainWindow.GridControls.cs
+++ b/Windows/MainWindow.GridControls.cs
@@ -50,6 +50,10 @@ namespace Edda {
             lblSelectedBeat.Content = "";
         }
         private void BorderSpectrogram_SizeChanged(object sender, SizeChangedEventArgs e) {
+            if (e.PreviousSize == new Size())
+            {
+                return;
+            }
             if (mapIsLoaded) {
                 gridController.DrawSpectrogram();
             }
@@ -62,6 +66,10 @@ namespace Edda {
 
         }
         private void ScrollEditor_SizeChanged(object sender, SizeChangedEventArgs e) {
+            if (e.PreviousSize == new Size())
+            {
+                return;
+            }
             if (mapIsLoaded) {
                 gridController.UpdateGridHeight();
             }


### PR DESCRIPTION
#46 Issue was caused by hanging autosave timer thread and map file references not being properly disposed of when closing the window.

Summary of the changes:
- Disposing of all the object references in MainWindow to avoid memory leaks and hanging threads when closing it.
- Implemented some guard rails for spectrogram generation, since it was being started multiple times when map was first being opened.
- Fixed an unusually large memory leaks caused by spectrogram generation trying to process too large BMPs.

Now the memory is manageable even for very large maps and is being (more or less) correctly released when closing a map and opening a different one.
![image](https://github.com/PKBeam/Edda/assets/12004018/8975fdf3-fddf-4c4e-bbed-28c5f2181859)


