### PR TITLE
Selecting all the notes in a bookmark/timing change

### DIFF
--- a/Classes/Helper.cs
+++ b/Classes/Helper.cs
@@ -306,23 +306,6 @@ public class Helper {
         }
         return null;
     }
-    public static bool InsertSortedUnique(List<Note> notes, Note note) {
-        // check which index to insert the new note at (keep everything in sorted order)
-        var i = 0;
-        foreach (var thisNote in notes) {
-            int comp = thisNote.CompareTo(note);
-            if (comp == 0) {
-                return false;
-            }
-            if (comp > 0) {
-                notes.Insert(i, note);
-                return true;
-            }
-            i++;
-        }
-        notes.Add(note);
-        return true;
-    }
     // TODO figure out a better way than this
     public static string UidGenerator(Note n) {
         return $"Note({Math.Round(n.beat, 4)},{n.col})";

--- a/Classes/Integrations/DiscordClient.cs
+++ b/Classes/Integrations/DiscordClient.cs
@@ -4,70 +4,68 @@ using DiscordRPC;
 
 public class DiscordClient {
     DiscordRpcClient client;
-	DateTime startTime;
-	bool enabled = false;
-	public DiscordClient() {
-		UpdateStartTime();
-	}
+    DateTime startTime;
+    bool enabled = false;
+    public DiscordClient() {
+        UpdateStartTime();
+    }
 
-	public void UpdateStartTime() {
-		startTime = DateTime.UtcNow;
-	}
+    public void UpdateStartTime() {
+        startTime = DateTime.UtcNow;
+    }
     public void SetPresence() {
-		SetPresence(null, 0);
+        SetPresence(null, 0);
     }
     public void SetPresence(string songName, int numNotes) {
-		if (!enabled) {
-			return;
+        if (!enabled) {
+            return;
         }
-		var rp = new RichPresence() {
-			Details = GetPresenceDetails(songName),
-			State = songName == null ? "" : $"{numNotes} notes placed",
-			Assets = new Assets() {
-				LargeImageKey = Edda.Const.DiscordRPC.IconKey
-			}
-		}.WithTimestamps(new Timestamps(startTime));
+        var rp = new RichPresence() {
+            Details = GetPresenceDetails(songName),
+            State = songName == null ? "" : $"{numNotes} notes placed",
+            Assets = new Assets() {
+                LargeImageKey = Edda.Const.DiscordRPC.IconKey
+            }
+        }.WithTimestamps(new Timestamps(startTime));
 
-		client.SetPresence(rp);
-	}
-
-	private string GetPresenceDetails(string songName)
-	{
-		switch (songName)
-		{
-			case null: return "No song open";
-			case "": return "Working on an untitled map";
-			default:
-				return $"Mapping: {songName}";
-
-        }
+        client.SetPresence(rp);
     }
 
-	public void Enable() {
-		var wasEnabled = enabled;
-		enabled = true;
-		if (!wasEnabled)
-		{
-			InitClient();
-		}
+    private string GetPresenceDetails(string songName)
+    {
+        return songName switch
+        {
+            null => "No song open",
+            "" => "Working on an untitled map",
+            _ => $"Mapping: {songName}",
+        };
     }
-	public void Disable() {
-		var wasEnabled = enabled; 
-		enabled = false;
-		if (wasEnabled)
-		{
+
+    public void Enable() {
+        var wasEnabled = enabled;
+        enabled = true;
+        if (!wasEnabled)
+        {
+            InitClient();
+        }
+    }
+    public void Disable() {
+        var wasEnabled = enabled; 
+        enabled = false;
+        if (wasEnabled)
+        {
             DeinitClient();
         }
-	}
-	private void InitClient() {
-		client = new DiscordRpcClient(Edda.Const.DiscordRPC.AppID);
-		client.Initialize();
-		SetPresence();
-	}
-	private void DeinitClient() {
-		if (client != null) {
-			client.Deinitialize();
-			client = null;
-		}
-	}
+    }
+    private void InitClient() {
+        client = new DiscordRpcClient(Edda.Const.DiscordRPC.AppID);
+        client.Initialize();
+        SetPresence();
+    }
+    private void DeinitClient() {
+        if (client != null) {
+            client.Deinitialize();
+            client = null;
+        }
+    }
 }

--- a/Classes/Integrations/DiscordClient.cs
+++ b/Classes/Integrations/DiscordClient.cs
@@ -22,7 +22,7 @@ public class DiscordClient {
 			return;
         }
 		var rp = new RichPresence() {
-			Details = songName == null ? "No song open" : $"Mapping: {songName}",
+			Details = GetPresenceDetails(songName),
 			State = songName == null ? "" : $"{numNotes} notes placed",
 			Assets = new Assets() {
 				LargeImageKey = Edda.Const.DiscordRPC.IconKey
@@ -31,6 +31,19 @@ public class DiscordClient {
 
 		client.SetPresence(rp);
 	}
+
+	private string GetPresenceDetails(string songName)
+	{
+		switch (songName)
+		{
+			case null: return "No song open";
+			case "": return "Mapping: *Untitled*";
+			default:
+				return $"Mapping: {songName}";
+
+        }
+    }
+
 	public void Enable() {
 		enabled = true;
 		InitClient();

--- a/Classes/Integrations/DiscordClient.cs
+++ b/Classes/Integrations/DiscordClient.cs
@@ -8,7 +8,6 @@ public class DiscordClient {
 	bool enabled = false;
 	public DiscordClient() {
 		UpdateStartTime();
-		InitClient();
 	}
 
 	public void UpdateStartTime() {
@@ -37,7 +36,7 @@ public class DiscordClient {
 		switch (songName)
 		{
 			case null: return "No song open";
-			case "": return "Mapping: *Untitled*";
+			case "": return "Working on an untitled map";
 			default:
 				return $"Mapping: {songName}";
 
@@ -45,13 +44,20 @@ public class DiscordClient {
     }
 
 	public void Enable() {
+		var wasEnabled = enabled;
 		enabled = true;
-		InitClient();
-	}
+		if (!wasEnabled)
+		{
+			InitClient();
+		}
+    }
 	public void Disable() {
+		var wasEnabled = enabled; 
 		enabled = false;
-		//client.ClearPresence();	this causes a null-dereference crash in the library
-		DeinitClient();
+		if (wasEnabled)
+		{
+            DeinitClient();
+        }
 	}
 	private void InitClient() {
 		client = new DiscordRpcClient(Edda.Const.DiscordRPC.AppID);

--- a/Classes/MapEditor/BPMChange.cs
+++ b/Classes/MapEditor/BPMChange.cs
@@ -21,7 +21,6 @@ public class BPMChange : IComparable {
         if (!(obj is BPMChange n)) {
             throw new Exception();
         }
-        BPMChange m = this;
-        return m.globalBeat.CompareTo(n.globalBeat);
+        return this.globalBeat.CompareTo(n.globalBeat);
     }
 }

--- a/Classes/MapEditor/Bookmark.cs
+++ b/Classes/MapEditor/Bookmark.cs
@@ -1,17 +1,37 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Edda {
-    public class Bookmark {
+    public class Bookmark : IComparable, IEquatable<Bookmark>
+    {
 
         public double beat { get; set; }
         public string name { get; set; }
         public Bookmark(double beat, string name) {
             this.beat = beat;
             this.name = name;
+        }
+
+        public int CompareTo(object obj)
+        {
+            if (!(obj is Bookmark b))
+            {
+                throw new Exception();
+            }
+            Bookmark that = this;
+            if (that.Equals(b))
+            {
+                return 0;
+            }
+            if (Helper.DoubleApproxGreater(that.beat, b.beat))
+            {
+                return 1;
+            }
+            return -1;
+        }
+
+        public bool Equals(Bookmark b)
+        {
+            return Helper.DoubleApproxEqual(b.beat, this.beat);
         }
     }
 }

--- a/Classes/MapEditor/Bookmark.cs
+++ b/Classes/MapEditor/Bookmark.cs
@@ -17,12 +17,11 @@ namespace Edda {
             {
                 throw new Exception();
             }
-            Bookmark that = this;
-            if (that.Equals(b))
+            if (this.Equals(b))
             {
                 return 0;
             }
-            if (Helper.DoubleApproxGreater(that.beat, b.beat))
+            if (Helper.DoubleApproxGreater(this.beat, b.beat))
             {
                 return 1;
             }

--- a/Classes/MapEditor/EditManager/EditList.cs
+++ b/Classes/MapEditor/EditManager/EditList.cs
@@ -9,7 +9,7 @@ public class EditList<T> : ICloneable {
     public EditList() {
         this.items = new List<Edit<T>>();
     }
-    public EditList(bool isAdding, List<T> items) {
+    public EditList(bool isAdding, IEnumerable<T> items) {
         this.items = new List<Edit<T>>();
         foreach (T item in items) {
             this.items.Add(new Edit<T>(isAdding, item));

--- a/Classes/MapEditor/MapEditor.cs
+++ b/Classes/MapEditor/MapEditor.cs
@@ -575,7 +575,7 @@ public class MapEditor : IDisposable {
             b.beat *= scaleFactor;
         }
     }
-    internal void ToggleSelectionForBookmark(Bookmark b)
+    internal void SelectNotesInBookmark(Bookmark b)
     {
         if (currentMapDifficulty == null)
         {
@@ -586,11 +586,19 @@ public class MapEditor : IDisposable {
             .Skip(1)
             .Select(x => x.beat)
             .FirstOrDefault(double.PositiveInfinity);
+        var notes = currentMapDifficulty.GetNotesRange(b.beat, endBeat);
 
-        ToggleSelection(currentMapDifficulty.GetNotesRange(b.beat, endBeat));
+
+        if (parent.shiftKeyDown)
+        {
+            ToggleSelection(notes);
+        } else
+        {
+            SelectNewNotes(notes);
+        }
     }
 
-    internal void ToggleSelectionForBPMChange(BPMChange bpmChange)
+    internal void SelectNotesInBPMChange(BPMChange bpmChange)
     {
         if (currentMapDifficulty == null)
         {
@@ -601,7 +609,15 @@ public class MapEditor : IDisposable {
             .Skip(1)
             .Select(x => x.globalBeat)
             .FirstOrDefault(double.PositiveInfinity);
+        var notes = currentMapDifficulty.GetNotesRange(bpmChange.globalBeat, endBeat);
 
-        ToggleSelection(currentMapDifficulty.GetNotesRange(bpmChange.globalBeat, endBeat));
+        if (parent.shiftKeyDown)
+        {
+            ToggleSelection(notes);
+        }
+        else
+        {
+            SelectNewNotes(notes);
+        }
     }
 }

--- a/Classes/MapEditor/MapEditor.cs
+++ b/Classes/MapEditor/MapEditor.cs
@@ -405,8 +405,7 @@ public class MapEditor : IDisposable {
 
         // Quantize each note and add it to the new list
         var quantizedNotes = currentMapDifficulty.selectedNotes
-            .Select(n =>
-            {
+            .Select(n => {
                 BPMChange lastBeatChange = GetLastBeatChange(n.beat);
                 double defaultGridLength = GetGridLength(lastBeatChange.BPM, lastBeatChange.gridDivision);
                 double offset = 0.0;
@@ -463,8 +462,7 @@ public class MapEditor : IDisposable {
             return;
         }
         var movedNotes = currentMapDifficulty.selectedNotes
-            .Select(n =>
-            {
+            .Select(n => {
                 BPMChange lastBeatChange = GetLastBeatChange(n.beat);
                 double beatOffset = 0.0;
                 switch (direction)
@@ -491,8 +489,7 @@ public class MapEditor : IDisposable {
         }
 
         var movedSelection = currentMapDifficulty.selectedNotes
-            .Select(n =>
-            {
+            .Select(n => {
                 int newCol = (n.col + offset) % 4;
                 if (newCol < 0)
                 {
@@ -586,7 +583,9 @@ public class MapEditor : IDisposable {
         }
         double endBeat = currentMapDifficulty.bookmarks
             .GetViewBetween(b, new Bookmark(double.PositiveInfinity, "songEnd"))
-            .Skip(1).Select(x => x.beat).FirstOrDefault(double.PositiveInfinity);
+            .Skip(1)
+            .Select(x => x.beat)
+            .FirstOrDefault(double.PositiveInfinity);
 
         ToggleSelection(currentMapDifficulty.GetNotesRange(b.beat, endBeat));
     }
@@ -599,7 +598,9 @@ public class MapEditor : IDisposable {
         }
         double endBeat = currentMapDifficulty.bpmChanges
             .GetViewBetween(bpmChange, new BPMChange(double.PositiveInfinity, 0, 0))
-            .Skip(1).Select(x => x.globalBeat).FirstOrDefault(double.PositiveInfinity);
+            .Skip(1)
+            .Select(x => x.globalBeat)
+            .FirstOrDefault(double.PositiveInfinity);
 
         ToggleSelection(currentMapDifficulty.GetNotesRange(bpmChange.globalBeat, endBeat));
     }

--- a/Classes/MapEditor/Note/Note.cs
+++ b/Classes/MapEditor/Note/Note.cs
@@ -13,14 +13,13 @@ public class Note: IComparable, IEquatable<Note> {
         if (!(obj is Note n)) {
             throw new Exception();
         }
-        Note m = this;
-        if (m.Equals(n)) {
+        if (this.Equals(n)) {
             return 0;
         }
-        if (Helper.DoubleApproxGreater(m.beat, n.beat)) {
+        if (Helper.DoubleApproxGreater(this.beat, n.beat)) {
             return 1;
         }
-        if (Helper.DoubleApproxEqual(n.beat, this.beat) && m.col > n.col) {
+        if (Helper.DoubleApproxEqual(n.beat, this.beat) && this.col > n.col) {
             return 1;
         }
         return -1;

--- a/Classes/MapEditor/Note/Note.cs
+++ b/Classes/MapEditor/Note/Note.cs
@@ -27,6 +27,6 @@ public class Note: IComparable, IEquatable<Note> {
     }
 
     public bool Equals(Note n) {
-        return Helper.DoubleApproxEqual(n.beat, this.beat) && Helper.DoubleApproxEqual(n.col, this.col);
+        return Helper.DoubleApproxEqual(n.beat, this.beat) && n.col == this.col;
     }
 }

--- a/Classes/UI/EditorGridController.cs
+++ b/Classes/UI/EditorGridController.cs
@@ -577,7 +577,7 @@ public class EditorGridController: IDisposable {
             txtBlock.PreviewMouseLeftButtonDown += new MouseButtonEventHandler((src, e) => {
                 if (parentWindow.ctrlKeyDown)
                 {
-                    mapEditor.ToggleSelectionForBookmark(b);
+                    mapEditor.SelectNotesInBookmark(b);
                 }
                 else
                 {
@@ -729,7 +729,7 @@ public class EditorGridController: IDisposable {
             bpmChangeFlagCanvas.PreviewMouseLeftButtonDown += new MouseButtonEventHandler((src, e) => {
                 if (parentWindow.ctrlKeyDown)
                 {
-                    mapEditor.ToggleSelectionForBPMChange(b);
+                    mapEditor.SelectNotesInBPMChange(b);
                 }
                 else
                 {
@@ -1110,7 +1110,7 @@ public class EditorGridController: IDisposable {
         txtBlock.MouseLeftButtonUp += new MouseButtonEventHandler((src, e) => {
             if (parentWindow.ctrlKeyDown)
             {
-                mapEditor.ToggleSelectionForBookmark(b);
+                mapEditor.SelectNotesInBookmark(b);
             }
             else
             {

--- a/Classes/UI/EditorGridController.cs
+++ b/Classes/UI/EditorGridController.cs
@@ -467,7 +467,8 @@ public class EditorGridController: IDisposable {
 
         // then draw the notes
         noteCanvas.Children.Clear();
-        DrawNotes(mapEditor.currentMapDifficulty.notes.ToList());
+        DrawNotes(mapEditor.currentMapDifficulty.notes);
+        HighlightNotes(mapEditor.currentMapDifficulty.selectedNotes);
 
         // including the mouseover preview note
         imgPreviewNote.Width = unitLength;
@@ -971,20 +972,18 @@ public class EditorGridController: IDisposable {
         double endBeat = mouseBeatUnsnapped;
         if (Helper.DoubleApproxGreater(startBeat, endBeat))
         {
-            var temp = endBeat;
-            endBeat = startBeat;
-            startBeat = temp;
+            (startBeat, endBeat) = (endBeat, startBeat);
         }
         int startCol = ColForPosition(dragSelectStart.X);
         int endCol = mouseGridCol;
-        if (endCol == -1) {
-            endCol = mousePos.X < EditorGrid.ActualWidth / 2 ? 0 : 3;
+        if (startCol > endCol)
+        {
+            (startCol, endCol) = (endCol, startCol);
         }
-        List<Note> newSelection =
+        var newSelection =
             mapEditor.currentMapDifficulty
                 .GetNotesRange(startBeat, endBeat)
-                .Where(n => n.col >= startCol && n.col <= endCol)
-                .ToList();
+                .Where(n => n.col >= Math.Max(startCol, 0) && n.col <= Math.Min(endCol, 3));
         if (parentWindow.shiftKeyDown) {
             mapEditor.SelectNotes(newSelection);
         } else {

--- a/Windows/DifficultyPredictorWindow.xaml.cs
+++ b/Windows/DifficultyPredictorWindow.xaml.cs
@@ -82,10 +82,10 @@ namespace Edda.Windows {
                 windowLower += step
                 windowUpper += step
         */
-        private double GetNoteDensity(List<Note> notes, double songDuration) {
-            return notes.Count / songDuration;
+        private double GetNoteDensity(IEnumerable<Note> notes, double songDuration) {
+            return notes.Count() / songDuration;
         }
-        private List<double> GetLocalNoteDensity(List<Note> notes, double songDuration, double globalBpm, double windowLength = 2.75, double step = 0.25) {
+        private List<double> GetLocalNoteDensity(IEnumerable<Note> notes, double songDuration, double globalBpm, double windowLength = 2.75, double step = 0.25) {
             var densities = new List<double>();
             var windowLower = 0.0;
             var windowUpper = windowLength;

--- a/Windows/MainWindow.GridControls.cs
+++ b/Windows/MainWindow.GridControls.cs
@@ -105,7 +105,7 @@ namespace Edda {
                 return;
             }
             Point mousePos = e.GetPosition(EditorGrid);
-            gridController.GridMouseMove(mousePos, shiftKeyDown);
+            gridController.GridMouseMove(mousePos);
 
             // update beat display
             lblSelectedBeat.Content = $"Time: {Helper.TimeFormat(gridController.snappedBeat * 60 / globalBPM)}, Global Beat: {Math.Round(gridController.snappedBeat, 3)} ({Math.Round(gridController.unsnappedBeat, 3)})";
@@ -147,7 +147,7 @@ namespace Edda {
                 return;
             }
             Point mousePos = e.GetPosition(EditorGrid);
-            gridController.GridMouseUp(mousePos, shiftKeyDown);
+            gridController.GridMouseUp(mousePos);
             editorMouseDown = false;
         }
         private void scrollEditor_PreviewMouseRightButtonUp(object sender, MouseButtonEventArgs e) {

--- a/Windows/MainWindow.UIControls.cs
+++ b/Windows/MainWindow.UIControls.cs
@@ -485,7 +485,7 @@ namespace Edda {
         private void BtnChangeBPM_Click(object sender, RoutedEventArgs e) {
             var win = Helper.GetFirstWindow<ChangeBPMWindow>();
             if (win == null) {
-                win = new ChangeBPMWindow(this, gridController.currentMapDifficultyBpmChanges);
+                win = new ChangeBPMWindow(this, gridController.currentMapDifficultyBpmChanges?.ToList());
                 win.Topmost = true;
                 win.Owner = this;
                 win.Show();
@@ -512,6 +512,7 @@ namespace Edda {
             recentMaps.AddRecentlyOpened((string)mapEditor.GetMapValue("_songName"), mapEditor.mapFolder);
             recentMaps.Write();
 
+            RefreshDiscordPresence();
         }
         private void TxtSongName_LostFocus(object sender, RoutedEventArgs e) {
             txtSongName.ScrollToHome();

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -20,6 +20,7 @@ using Path = System.IO.Path;
 using Timer = System.Timers.Timer;
 using SoundTouch.Net.NAudioSupport;
 using Edda.Const;
+using System.Linq;
 
 /// <summary>
 /// Interaction logic for MainWindow.xaml
@@ -100,8 +101,8 @@ namespace Edda {
         public EditorGridController gridController;
         Timer autosaveTimer;
         UserSettingsManager userSettings;
-        bool shiftKeyDown;
-        bool ctrlKeyDown;
+        public bool shiftKeyDown;
+        public bool ctrlKeyDown;
         bool returnToStartMenuOnClose = false;
 
         DoubleAnimation songPlayAnim;            // used for animating scroll when playing a song
@@ -301,7 +302,7 @@ namespace Edda {
                 this.Dispatcher.Invoke(() => DrawEditorGrid(false));
             })).Start();
 
-            discordClient.SetPresence((string)mapEditor.GetMapValue("_songName"), gridController.currentMapDifficultyNotes?.Count ?? 0);
+            RefreshDiscordPresence();
         }
         // ... future actions will call these functions
         private void CreateNewMap() {
@@ -1296,6 +1297,12 @@ namespace Edda {
             }
             return !(res.HasValue && res.Value == MessageBoxResult.Cancel);
         }
+
+        internal void RefreshDiscordPresence()
+        {
+            discordClient.SetPresence((string)mapEditor.GetMapValue("_songName"), gridController.currentMapDifficultyNotes?.Count() ?? 0);
+        }
+
         internal void RefreshBPMChanges() {
             var win = Helper.GetFirstWindow<ChangeBPMWindow>();
             if (win != null) {

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -251,6 +251,8 @@ namespace Edda {
 
             recentMaps.AddRecentlyOpened((string)mapEditor.GetMapValue("_songName"), newMapFolder);
             recentMaps.Write();
+
+            RefreshDiscordPresence();
         }
         internal void InitImportMap(string importMapFolder) {
             if (mapIsLoaded) {
@@ -804,6 +806,7 @@ namespace Edda {
 
             playbackDeviceID = userPreferredPlaybackDeviceID;
 
+            SetDiscordRPC(userSettings.GetBoolForKey(UserSettingsKey.EnableDiscordRPC));
             autosaveTimer.Enabled = userSettings.GetBoolForKey(UserSettingsKey.EnableAutosave);
 
         }
@@ -1298,9 +1301,25 @@ namespace Edda {
             return !(res.HasValue && res.Value == MessageBoxResult.Cancel);
         }
 
+        internal void SetDiscordRPC(bool enable)
+        {
+            if (enable)
+            {
+                discordClient.Enable();
+                RefreshDiscordPresence();
+            }
+            else
+            {
+                discordClient.Disable();
+            }
+        }
+
         internal void RefreshDiscordPresence()
         {
-            discordClient.SetPresence((string)mapEditor.GetMapValue("_songName"), gridController.currentMapDifficultyNotes?.Count() ?? 0);
+            if (mapEditor != null && gridController != null)
+            {
+                discordClient.SetPresence((string)mapEditor.GetMapValue("_songName"), gridController.currentMapDifficultyNotes?.Count() ?? 0);
+            }
         }
 
         internal void RefreshBPMChanges() {


### PR DESCRIPTION
#57 Implemented selection toggle of all the notes in specific bookmark/timing change on Ctrl+LeftClick.

To streamline certain operations, refactored MapDifficulty to store all notes, bookmarks and timing changes as SortedSet instead of List.

Implemented more frequent updates to the Discord Presence to better reflect the current status of user.