### PR TITLE
Bug: Old versions do not exit, leaves a thread with no purpose

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -24,16 +24,24 @@ namespace RagnarockEditor
 
             // for testing cultures
             //CultureInfo.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("fr-FR");
+        }
 
-            try {
-                if (UserSettings.GetValueForKey(UserSettingsKey.CheckForUpdates) == true.ToString()) {
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            try
+            {
+                if (UserSettings.GetBoolForKey(UserSettingsKey.CheckForUpdates))
+                {
                     //#if !DEBUG
                     Helper.CheckForUpdates();
                     //#endif
                 }
-            } catch {
+            }
+            catch
+            {
                 Trace.WriteLine("INFO: Could not check for updates.");
             }
+            base.OnStartup(e);
         }
 
         public void SetDiscordRPC(bool enable) {


### PR DESCRIPTION
#66
Fixed an issue with Check Update dialog blocking main application window startup.