### PR TITLE
Force cover image to be a square

### DIFF
--- a/Classes/Helper.cs
+++ b/Classes/Helper.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Drawing;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -105,6 +106,23 @@ public class Helper {
         }
         return BeatmapDefaults.CoverFilename + coverExtension;
     }
+    public static bool IsValidCoverFile(string fileName) {
+        BitmapImage img = BitmapGenerator(new Uri(fileName));
+        return img.PixelWidth == img.PixelHeight;
+    }
+
+    public static string TrimCoverFile(string fileName) {
+        using Image src = Image.FromFile(fileName);
+        var size = Math.Min(src.Width, src.Height);
+        var cropRect = new Rectangle((src.Width - size) / 2, (src.Height - size) / 2, size, size);
+        using Bitmap target = new(size, size);
+        using Graphics g = Graphics.FromImage(target);
+        g.DrawImage(src, new Rectangle(0, 0, size, size), cropRect, GraphicsUnit.Pixel);
+        string newFileName = Path.GetTempPath() + Path.GetRandomFileName() + Path.GetExtension(fileName);
+        target.Save(newFileName);
+        return newFileName;
+    }
+
     public static string DefaultRagnarockMapPath() {
         string docPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
         string ragPath = Path.Combine(docPath, "Ragnarock");
@@ -332,7 +350,7 @@ public class Helper {
         return new Uri($"pack://application:,,,/resources/{file}");
     }
     public static BitmapImage BitmapGenerator(string resourceFile) {
-        return BitmapGenerator(new Uri($"pack://application:,,,/resources/{resourceFile}"));
+        return BitmapGenerator(UriForResource(resourceFile));
     }
     public static BitmapImage BitmapImageForBeat(double beat, bool isHighlighted = false) {
         double fracBeat = beat - (int)beat;

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -833,20 +833,35 @@ namespace Edda {
                 return;
             }
 
+            string sourceFile = d.FileName;
+
+            if (!Helper.IsValidCoverFile(sourceFile)) {
+                var coverTrimResult = MessageBox.Show(this, $"Ragnarock will only display square cover images. Do you want Edda to create and use a cropped version of the selected image instead?", "Warning", MessageBoxButton.YesNoCancel, MessageBoxImage.Warning);
+                switch (coverTrimResult) {
+                    case MessageBoxResult.Yes:
+                        sourceFile = Helper.TrimCoverFile(sourceFile);
+                        break;
+                    case MessageBoxResult.No:
+                        break; // Continue
+                    case MessageBoxResult.Cancel:
+                        return; // Cancel the whole operation
+                }
+            }
+
             imgCover.Source = null;
 
             string prevPath = Path.Combine(mapEditor.mapFolder, (string)mapEditor.GetMapValue("_coverImageFilename"));
-            string newFile = Helper.SanitiseCoverFileName(d.FileName);
+            string newFile = Helper.SanitiseCoverFileName(sourceFile);
             string newPath = Path.Combine(mapEditor.mapFolder, newFile);
 
             // skip only when the chosen file is already the map cover file
-            if (prevPath != d.FileName) {
+            if (prevPath != sourceFile) {
                 // remove the previous cover image
                 Helper.FileDeleteIfExists(prevPath);
                 // delete any existing files in the map folder with conflicting names
                 Helper.FileDeleteIfExists(newPath);
                 // copy image file over
-                File.Copy(d.FileName, newPath);
+                File.Copy(sourceFile, newPath);
 
                 mapEditor.SetMapValue("_coverImageFilename", newFile);
                 SaveBeatmap();


### PR DESCRIPTION
#72
Implemented square check for cover images. It's not mandatory, but there's a popup informing user that the selected image will not be displayed in-game with an option to crop it automatically.
![image](https://github.com/PKBeam/Edda/assets/12004018/d6397a63-3caf-4154-a5c4-504097536b6c)
![image](https://github.com/PKBeam/Edda/assets/12004018/77e1b42e-8631-446c-bf98-6819a15a1a0c)
![image](https://github.com/PKBeam/Edda/assets/12004018/84960cb0-f48e-4449-ba10-8cd970928a31)
