### PR TITLE
Edda crashes if the selected audio device is not plugged in

### DIFF
--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -83,6 +83,10 @@ namespace Edda {
                 if (!string.IsNullOrEmpty(playbackDeviceID)) {
                     try {
                         device = deviceEnumerator.GetDevice(playbackDeviceID);
+                        if (!device.State.HasFlag(DeviceState.Active)) {
+                            // Fallback to default device if the preferred device isn't available.
+                            device = null;
+                        }
                     } catch (Exception ex) {
                         Trace.WriteLine($"WARNING: Couldn't get the playback device with ID {playbackDeviceID} due to an error:\n{ex.Message}.\n{ex.StackTrace}", "Warning");
                         playbackDeviceID = null;


### PR DESCRIPTION
#92 

Added a check for whether preferred output device is available at the time of running Edda.