### PR TITLE
Include info about Triple and Quadruple notes on a line

### DIFF
--- a/Classes/EddaConstants.cs
+++ b/Classes/EddaConstants.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Windows;
 using System.Windows.Media;
 
 namespace Edda.Const {
@@ -150,6 +151,12 @@ namespace Edda.Const {
             public const double NameSize = 11;
             public const double NamePadding = 3;
             public const double Opacity = 0.75;
+        }
+        public static class Stats {
+            public static readonly MediaColor Colour = Colors.Black;
+            public static readonly MediaColor WarningColour = Colors.Crimson;
+            public static readonly FontWeight FontWeight = FontWeights.Regular;
+            public static readonly FontWeight WarningFontWeight = FontWeights.Bold;
         }
 
         // Waveform drawing

--- a/Classes/MapEditor/Stats/MapStats.cs
+++ b/Classes/MapEditor/Stats/MapStats.cs
@@ -17,6 +17,8 @@ namespace Edda.Classes.MapEditor.Stats {
         public int selectedNotes;
         public int singleNotes;
         public int doubleNotes;
+        public int tripleNotes;
+        public int quadrupleNotes;
 
         /// <summary>
         /// Column variety
@@ -49,6 +51,8 @@ namespace Edda.Classes.MapEditor.Stats {
             this.selectedNotes = selectedNotes.Count;
             singleNotes = CalculateRowNotes(notes, 1);
             doubleNotes = CalculateRowNotes(notes, 2);
+            tripleNotes = CalculateRowNotes(notes, 3);
+            quadrupleNotes = CalculateRowNotes(notes, 4);
         }
 
         private static int CalculateRowNotes(SortedSet<Note> notes, int rowCount) {

--- a/Windows/MainWindow.xaml
+++ b/Windows/MainWindow.xaml
@@ -274,7 +274,7 @@
                             <Grid VerticalAlignment="Center">
                                 <Grid.Resources>
                                     <Style TargetType="Border" >
-                                        <Setter Property="Padding" Value="5,1,5,1" />
+                                        <Setter Property="Padding" Value="2.5,1,2.5,1" />
                                     </Style>
                                 </Grid.Resources>
                                 <Grid.RowDefinitions>
@@ -282,10 +282,11 @@
                                     <RowDefinition Height="*" />
                                 </Grid.RowDefinitions>
                                 <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="0.9*" />
+                                    <ColumnDefinition Width="0.85*" />
+                                    <ColumnDefinition Width="0.9*" />
                                     <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="0.95*" />
                                 </Grid.ColumnDefinitions>
                                 <Border Grid.Row="0" Grid.Column="0">
                                     <TextBlock VerticalAlignment="Center">All</TextBlock>
@@ -299,6 +300,9 @@
                                 <Border Grid.Row="0" Grid.Column="3">
                                     <TextBlock VerticalAlignment="Center">Double</TextBlock>
                                 </Border>
+                                <Border Grid.Row="0" Grid.Column="4">
+                                    <TextBlock x:Name="notesStatsTriplePlusLabel" VerticalAlignment="Center">Triple+</TextBlock>
+                                </Border>
                                 <Border Grid.Row="1" Grid.Column="0">
                                     <TextBlock x:Name="notesStatsAll" VerticalAlignment="Center">734</TextBlock>
                                 </Border>
@@ -311,9 +315,13 @@
                                 <Border Grid.Row="1" Grid.Column="3">
                                     <TextBlock x:Name="notesStatsDouble" VerticalAlignment="Center">210</TextBlock>
                                 </Border>
+                                <Border Grid.Row="1" Grid.Column="4">
+                                    <TextBlock x:Name="notesStatsTriplePlus" VerticalAlignment="Center">0</TextBlock>
+                                </Border>
                                 <Border Grid.RowSpan="2" Grid.Column="0" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" BorderThickness="0,0,1,0"/>
                                 <Border Grid.RowSpan="2" Grid.Column="1" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" BorderThickness="0,0,1,0"/>
                                 <Border Grid.RowSpan="2" Grid.Column="2" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" BorderThickness="0,0,1,0"/>
+                                <Border Grid.RowSpan="2" Grid.Column="3" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" BorderThickness="0,0,1,0"/>
                             </Grid>
                         </Expander>
                         <Border BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" BorderThickness="0,0,0,1"/>

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -1409,6 +1409,16 @@ namespace Edda {
             notesStatsSelected.Text = stats.selectedNotes.ToString();
             notesStatsSingle.Text = stats.singleNotes.ToString();
             notesStatsDouble.Text = stats.doubleNotes.ToString();
+            var triplePlusNotes = stats.tripleNotes + stats.quadrupleNotes;
+            notesStatsTriplePlus.Text = triplePlusNotes.ToString();
+            var triplePlusFontWeight = triplePlusNotes > 0 ? Editor.Stats.WarningFontWeight : Editor.Stats.FontWeight;
+            notesStatsTriplePlusLabel.FontWeight = triplePlusFontWeight;
+            notesStatsTriplePlus.FontWeight = triplePlusFontWeight;
+            var triplePlusColor = new SolidColorBrush(
+                triplePlusNotes > 0 ? Editor.Stats.WarningColour : Editor.Stats.Colour
+            );
+            notesStatsTriplePlusLabel.Foreground = triplePlusColor;
+            notesStatsTriplePlus.Foreground = triplePlusColor;
         }
 
         private void SetColumnStats(MapStats stats) {


### PR DESCRIPTION
#91

Added stats indicator for Triple/Quadruple notes on a row.

![image](https://github.com/PKBeam/Edda/assets/12004018/43f91cec-e7bb-4860-8e22-f59c697eba56)
![image](https://github.com/PKBeam/Edda/assets/12004018/3794ae9f-3eac-401f-8439-bae7670b46e3)
