### PR TITLE
Bump the version to 1.2.4

### DIFF
--- a/Classes/EddaConstants.cs
+++ b/Classes/EddaConstants.cs
@@ -13,7 +13,7 @@ namespace Edda.Const {
         public const string Name = "Edda";
         public const string RepositoryURL = "https://github.com/PKBeam/Edda";
         public const string ReleasesAPI = "https://api.github.com/repos/PKBeam/Edda/releases";
-        public const string BaseVersionString = "1.2.3";
+        public const string BaseVersionString = "1.2.4";
         public const string VersionString =
 #if DEBUG
             BaseVersionString + "-dev";


### PR DESCRIPTION
Release notes for 1.2.4:

## New features
* Include info about Triple and Quadruple notes on a line by @Brollyy in https://github.com/PKBeam/Edda/pull/97
* Implement scroll wheel hold by @Brollyy in https://github.com/PKBeam/Edda/pull/103

## Bugfixes
* Fixed a crash if the selected audio device is not plugged in by @Brollyy in https://github.com/PKBeam/Edda/pull/95
* Fixed a crash when trying to select a file `cover.jpg` for the map cover by @Brollyy in https://github.com/PKBeam/Edda/pull/96

## Other
**Note**: Edda is now using .NET 8.0. You need to download the [.NET 8.0 Runtime](https://dotnet.microsoft.com/download/dotnet/8.0/runtime) if you plan on using the `NoRuntime` executable.
Edda is now released under a [GPL-3.0 license](https://github.com/PKBeam/Edda?tab=GPL-3.0-1-ov-file#GPL-3.0-1-ov-file)

Once this version bump and the pending PR with scroll wheel hold are merged, I'll build the new executables and publish the release.