### PR TITLE
_lineLayer is not a required value for official maps

### DIFF
--- a/Classes/MapEditor/RagnarockMap.cs
+++ b/Classes/MapEditor/RagnarockMap.cs
@@ -517,7 +517,10 @@ public class RagnarockMap {
                                 throw ex;
                             break;
                         case "_lineLayer":
-                            if (val != 1) throw ex;
+                            // Technically, we should only have notes on layer 1, but the game doesn't complain if the notes are on different layers.
+                            // See https://github.com/PKBeam/Edda/issues/112.
+                            if ((int)val != val || val < 0 || 3 < val)
+                                throw ex;
                             break;
                         case "_type":
                             if (val != 0) throw ex;


### PR DESCRIPTION
#112 Adjusted validation for the map data to allow maps that use a different _lineLayer than the default one.