### PR TITLE
Error while importing SM map into Edda

### DIFF
--- a/Classes/Helper.cs
+++ b/Classes/Helper.cs
@@ -223,7 +223,9 @@ public class Helper {
         string path = Path.Combine(Path.GetTempPath(), $"ffmpeg_temp_{Process.GetCurrentProcess().Id}.exe");
         File.WriteAllBytes(path, Edda.Properties.Resources.ffmpeg);
 
-        var p = Process.Start(path, arg);
+        var startInfo = new ProcessStartInfo(path, arg);
+        startInfo.WorkingDirectory = dir;
+        var p = Process.Start(startInfo);
         p.WaitForExit();
         int exitCode = p.ExitCode;
         p.Close(); // To free up the handle on ffmpeg_temp_{pid}.exe


### PR DESCRIPTION
#113 #90 

Fixed several issues in Stepmania converter:
1. If there was no map author information, Edda refused to import the simfile instead of defaulting to empty Mapper field.
2. When there was a positive song offset and only one BPM change in the simfile, no notes were imported.
3. Simfiles that used MP3 song format were failing to import with very confusing error message - added an attempt to convert the MP3 into OGG Vorbis to at least try to handle this use case.