### PR TITLE
Release 1.2.5 version bump

### DIFF
--- a/Classes/EddaConstants.cs
+++ b/Classes/EddaConstants.cs
@@ -13,7 +13,7 @@ namespace Edda.Const {
         public const string Name = "Edda";
         public const string RepositoryURL = "https://github.com/PKBeam/Edda";
         public const string ReleasesAPI = "https://api.github.com/repos/PKBeam/Edda/releases";
-        public const string BaseVersionString = "1.2.4";
+        public const string BaseVersionString = "1.2.5";
         public const string VersionString =
 #if DEBUG
             BaseVersionString + "-dev";


### PR DESCRIPTION
Release notes for 1.2.5:

## New features
* Implemented a new, more accurate Difficulty Predictor model trained on OST and RAID songs. by @Nytilde, @Brollyy in https://github.com/PKBeam/Edda/pull/110

## Bugfixes
* Fixed the issue with incorrect format after trimming the cover image. by @Brollyy in https://github.com/PKBeam/Edda/pull/107
* Fixed an issue where maps saved by in-game editor couldn't be re-opened in Edda. by @Brollyy in https://github.com/PKBeam/Edda/pull/108
* Error while importing SM map into Edda by @Brollyy in https://github.com/PKBeam/Edda/pull/115
* Cannot import SM map that's using MP3 audio file. by @Brollyy in https://github.com/PKBeam/Edda/pull/115
* _lineLayer is not a required value for official maps by @Brollyy in https://github.com/PKBeam/Edda/pull/114


Release draft available at https://github.com/PKBeam/Edda/releases/edit/untagged-03328dbe2d02a0734261