### PR TITLE
Fixed incorrect symbols for 1/6th and 5/6th runes.

### DIFF
--- a/Classes/Helper.cs
+++ b/Classes/Helper.cs
@@ -375,13 +375,13 @@ public class Helper {
         if (DoubleApproxEqual(fracBeat, 1.0 / 4.0)) {
             runeStr = "14";
         }
-        if (DoubleApproxEqual(fracBeat, 1.0 / 3.0)) {
+        if (DoubleApproxEqual(fracBeat, 1.0 / 3.0) || DoubleApproxEqual(fracBeat, 5.0 / 6.0)) {
             runeStr = "13";
         }
         if (DoubleApproxEqual(fracBeat, 1.0 / 2.0)) {
             runeStr = "12";
         }
-        if (DoubleApproxEqual(fracBeat, 2.0 / 3.0)) {
+        if (DoubleApproxEqual(fracBeat, 2.0 / 3.0) || DoubleApproxEqual(fracBeat, 1.0 / 6.0)) {
             runeStr = "23";
         }
         if (DoubleApproxEqual(fracBeat, 3.0 / 4.0)) {


### PR DESCRIPTION
#121

![image](https://github.com/PKBeam/Edda/assets/12004018/e7ad6aac-7dbd-403b-ab02-6ec6e67c3122)
