### PR TITLE
Use ratio for scaling mapping area instead of absolute scaling

### DIFF
--- a/Windows/MainWindow.GridControls.cs
+++ b/Windows/MainWindow.GridControls.cs
@@ -229,6 +229,20 @@ namespace Edda {
                 editorIsLoaded = true;
             }), System.Windows.Threading.DispatcherPriority.ContextIdle);
         }
+
+        private void EditorPanel_SizeChanged(object sender, SizeChangedEventArgs e) {
+            /**
+             * FIXME: the ratio of the spectrogram column is still not the same after resizing down in a way that makes the EditorPanel wider than the slot in the DockPanel.
+             *        In this situation, this event doesn't trigger unless height is changed as well.
+             *        If the height changes as well, this even handler will resize the width down, which triggers the event again (this time for width change) and the resulting ratio is not the same.
+             * Replication steps: increase window width, drag spectrogram column as far right as possible and then reduce the window width.
+             **/
+            if (editorIsLoaded) {
+                var previousSpectrogramRatio = (gridSpectrogram.ActualWidth - spectrogramResize.Width) / e.PreviousSize.Width;
+                var newSpectrogramWidth = Math.Min(EditorPanel.ActualWidth, EditorPanel.MaxWidth) * previousSpectrogramRatio;
+                gridSpectrogram.ColumnDefinitions[0].Width = new GridLength(newSpectrogramWidth);
+            }
+        }
     }
 
     public class DoubleOffsetConverter : IValueConverter {

--- a/Windows/MainWindow.xaml
+++ b/Windows/MainWindow.xaml
@@ -10,8 +10,9 @@
     <Window.Resources>
         <edda:DoubleOffsetConverter x:Key="SpectrogramColumnMaxWidthConverter" Offset="320"/>
         <edda:DoubleOffsetConverter x:Key="SpectrogramResizeMaxWidthConverter" Offset="323"/>
+        <edda:DoubleOffsetConverter x:Key="EditorPanelMaxWidthConverter" Offset="450"/>
     </Window.Resources>
-    <DockPanel>
+    <DockPanel x:Name="DockPanel">
         <Border DockPanel.Dock="Top" Name="TopPanel" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" BorderThickness="0, 0, 0, 1">
             <Border.Background>
                 <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
@@ -694,7 +695,7 @@
                 </ScrollViewer>
             </DockPanel>
         </Border>
-        <Grid Name="EditorPanel" MinWidth="300">
+        <Grid Name="EditorPanel" SizeChanged="EditorPanel_SizeChanged" MinWidth="300" MaxWidth="{Binding ElementName=DockPanel, Path=ActualWidth, Converter={StaticResource EditorPanelMaxWidthConverter}}">
             <Grid.Background>
                 <ImageBrush ImageSource="/Resources/waterTexture.png" TileMode="Tile" ViewportUnits="Absolute" Viewport="0,0,256,256"/>
             </Grid.Background>


### PR DESCRIPTION
#125 
Workaround for the spectrogram column taking up the whole editor panel after resizing the window down.