### PR TITLE
Release 1.2.6

### DIFF
--- a/Classes/EddaConstants.cs
+++ b/Classes/EddaConstants.cs
@@ -13,7 +13,7 @@ namespace Edda.Const {
         public const string Name = "Edda";
         public const string RepositoryURL = "https://github.com/PKBeam/Edda";
         public const string ReleasesAPI = "https://api.github.com/repos/PKBeam/Edda/releases";
-        public const string BaseVersionString = "1.2.5";
+        public const string BaseVersionString = "1.2.6";
         public const string VersionString =
 #if DEBUG
             BaseVersionString + "-dev";

--- a/Classes/MapEditor/Stats/DifficultyPredictorNytilde.cs
+++ b/Classes/MapEditor/Stats/DifficultyPredictorNytilde.cs
@@ -29,7 +29,7 @@ namespace Edda.Classes.MapEditorNS.Stats {
             var maxTime = timeSeries.Last() - timeSeries.First();
 
             var noteDensity = GetNoteDensity(timeSeries, maxTime);
-            var averageTimeDifference = timeDifferencesNoZero.Average();
+            var averageTimeDifference = timeDifferencesNoZero.Count > 0 ? timeDifferencesNoZero.Average() : 0.0;
             var melchiorDiffScore = GetMelchiorDifficultyScore(diff.notes, mapEditor.GlobalBPM);
             var localNoteDensity = GetNoteDensitiesPerWindow(timeSeries, 2);
             var highLocalNoteDensity = Helper.GetQuantile(localNoteDensity, 0.95);


### PR DESCRIPTION
- [x] Merge #129 before the release

# Release Notes

## New features
* Due to many reports of instability in the new Difficulty Predictor, you can now choose between the old ML model created by @PKBeam (default), the new ML model created by @Nytilde (marked as beta for now), or a new algorithm based on distances between runes suggested by Melchior. by @Brollyy, @Nytilde, Melchior in #129
* Added an option to display the Difficulty Prediction for current map next to Map Stats, in real-time. by @Brollyy in https://github.com/PKBeam/Edda/pull/124

## Bugfixes
* Fixed incorrect symbols for 1/6th and 5/6th runes. by @Brollyy in https://github.com/PKBeam/Edda/pull/122
* Song stats don't refresh after deleting difficulty by @Brollyy in https://github.com/PKBeam/Edda/pull/123
* Error while importing SM map into Edda by @Brollyy in https://github.com/PKBeam/Edda/pull/117
* Export Map included too many files by @Brollyy in https://github.com/PKBeam/Edda/pull/127
* Improved spectrogram bar width handling when the window is resized by @Brollyy in https://github.com/PKBeam/Edda/pull/128

**Full Changelog**: https://github.com/PKBeam/Edda/compare/v1.2.5...v1.2.6