### PR TITLE
Improve clipboard support

### DIFF
--- a/Classes/Audio/AudioScanner.cs
+++ b/Classes/Audio/AudioScanner.cs
@@ -1,4 +1,5 @@
-﻿using Edda.Const;
+﻿using Edda.Classes.MapEditorNS.NoteNS;
+using Edda.Const;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/Classes/Audio/BeatScanner.cs
+++ b/Classes/Audio/BeatScanner.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Edda.Classes.MapEditorNS.NoteNS;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;

--- a/Classes/Audio/NoteScanner.cs
+++ b/Classes/Audio/NoteScanner.cs
@@ -1,4 +1,5 @@
 ﻿using Edda;
+using Edda.Classes.MapEditorNS.NoteNS;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/Classes/EddaConstants.cs
+++ b/Classes/EddaConstants.cs
@@ -64,6 +64,7 @@ namespace Edda.Const {
         public const string DifficultyPredictorAlgorithm = DifficultyPrediction.SupportedAlgorithms.PKBeam;
         public const bool DifficultyPredictorShowPrecise = false;
         public const bool DifficultyPredictorShowInMapStats = false;
+        public const string NotePasteBehavior = Editor.DefaultNotePasteBehavior;
     }
 
     public static class UserSettingsKey {
@@ -91,12 +92,14 @@ namespace Edda.Const {
         public const string DifficultyPredictorAlgorithm = "difficultyPredictorAlgorithm";
         public const string DifficultyPredictorShowPrecise = "difficultyPredictorShowPrecise";
         public const string DifficultyPredictorShowInMapStats = "difficultyPredictorShowInMapStats";
+        public const string NotePasteBehavior = "notePasteBehavior";
     }
     public static class Editor {
         // Grid drawing
         public const int DefaultNoteSpeed = 20;
         public const int DefaultGridSpacing = 2;
         public const int DefaultGridDivision = 4;
+        public const string DefaultNotePasteBehavior = NotePasteBehavior.AlignToNoteBPM;
         public const double GridDrawRange = 1;
         public const int DrawDebounceInterval = 100; // ms
         public const string MajorGridlineColour = "#333333";
@@ -115,6 +118,13 @@ namespace Edda.Const {
         public const double PreviewNoteOpacity = 0.30; // percentage of 1.0
         public const double DragInitThreshold = 10; // pixels
         public const int AutosaveInterval = 30; // seconds
+
+        // Note Paste Behavior
+        public static class NotePasteBehavior {
+            public const string AlignToGlobalBeat = "AlignToGlobalBeat"; // paste notes as-if they were copied from the same global BPM and disregard any BPM changes.
+            public const string AlignToFirstNoteBPM = "AlignToFirstNoteBPM"; // paste notes only scaling by a factor based on the first pasted note BPM and mouse position BPM.
+            public const string AlignToNoteBPM = "AlignToNoteBPM"; // paste notes by aligning each note timing based on all the BPM changes in the pasted notes and mouse position BPM.
+        }
 
         // Hold Scrolling
         public static class HoldScroll {

--- a/Classes/MapConverters/StepManiaMapConverter.cs
+++ b/Classes/MapConverters/StepManiaMapConverter.cs
@@ -1,3 +1,5 @@
+using Edda.Classes.MapEditorNS;
+using Edda.Classes.MapEditorNS.NoteNS;
 using Edda.Const;
 using StepmaniaUtils;
 using StepmaniaUtils.Enums;

--- a/Classes/MapEditor/BPMChange.cs
+++ b/Classes/MapEditor/BPMChange.cs
@@ -1,26 +1,29 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-public class BPMChange : IComparable {
-    public double globalBeat { get; set; }
-    public double BPM { get; set; }
-    public int gridDivision { get; set; }
+namespace Edda.Classes.MapEditorNS {
+    [Serializable]
+    public class BPMChange(double globalBeat, double BPM, int gridDivision) : IComparable, IEquatable<BPMChange> {
+        public double globalBeat = globalBeat;
+        public double BPM = BPM;
+        public int gridDivision = gridDivision;
 
-    public BPMChange(double globalBeat, double BPM, int gridDivision) {
-        this.globalBeat = globalBeat;
-        this.BPM = BPM;
-        this.gridDivision = gridDivision;
-    }
+        public BPMChange() : this(0, 120, 4) { }
 
-    public BPMChange() : this(0, 120, 4) { }
-
-    public int CompareTo(object obj) {
-        if (!(obj is BPMChange n)) {
-            throw new Exception();
+        public int CompareTo(object obj) {
+            if (obj is not BPMChange b) {
+                throw new Exception();
+            }
+            if (Helper.DoubleApproxEqual(globalBeat, b.globalBeat)) {
+                return 0;
+            }
+            if (Helper.DoubleApproxGreater(globalBeat, b.globalBeat)) {
+                return 1;
+            }
+            return -1;
         }
-        return this.globalBeat.CompareTo(n.globalBeat);
+
+        public override bool Equals(object obj) => obj is BPMChange b && Equals(b);
+        public override int GetHashCode() => HashCode.Combine(Math.Round(globalBeat, 4), Math.Round(BPM, 4), gridDivision);
+        public bool Equals(BPMChange b) => Helper.DoubleApproxEqual(globalBeat, b.globalBeat) && Helper.DoubleApproxEqual(BPM, b.BPM) && gridDivision == b.gridDivision;
     }
 }

--- a/Classes/MapEditor/BPMChange.cs
+++ b/Classes/MapEditor/BPMChange.cs
@@ -3,9 +3,9 @@
 namespace Edda.Classes.MapEditorNS {
     [Serializable]
     public class BPMChange(double globalBeat, double BPM, int gridDivision) : IComparable, IEquatable<BPMChange> {
-        public double globalBeat = globalBeat;
-        public double BPM = BPM;
-        public int gridDivision = gridDivision;
+        public double globalBeat { get; set; } = globalBeat;
+        public double BPM { get; set; } = BPM;
+        public int gridDivision { get; set; } = gridDivision;
 
         public BPMChange() : this(0, 120, 4) { }
 

--- a/Classes/MapEditor/MapEditor.cs
+++ b/Classes/MapEditor/MapEditor.cs
@@ -1,10 +1,15 @@
 ﻿using Edda;
+using Edda.Classes.MapEditorNS;
+using Edda.Classes.MapEditorNS.NoteNS;
 using Edda.Classes.MapEditorNS.Stats;
 using Edda.Const;
 using Newtonsoft.Json.Linq;
+using RagnaRuneString;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Windows.Forms;
 
 #nullable enable
 
@@ -64,7 +69,6 @@ public class MapEditor : IDisposable {
     public int currentDifficultyIndex = -1;
     MapStats currentDifficultyStats;
     MapDifficulty?[] difficultyMaps = new MapDifficulty[3];
-    SortedSet<Note> clipboard;
 
     public bool needsSave = false;
 
@@ -87,6 +91,12 @@ public class MapEditor : IDisposable {
             songDuration = value;
             currentDifficultyStats.songDuration = value;
             RecalculateMapStats();
+        }
+    }
+
+    public string NotePasteBehavior {
+        get {
+            return parent.GetUserSetting(UserSettingsKey.NotePasteBehavior);
         }
     }
 
@@ -126,14 +136,13 @@ public class MapEditor : IDisposable {
             );
         }
         this.currentDifficultyStats = new MapStats(globalBPM, songDuration);
-        this.clipboard = new();
     }
 
     public void Dispose() {
         beatMap = null;
         parent = null;
         difficultyMaps = null;
-        clipboard = null;
+        GC.SuppressFinalize(this);
     }
 
     public MapDifficulty? GetDifficulty(int indx) {
@@ -377,7 +386,9 @@ public class MapEditor : IDisposable {
         if (currentMapDifficulty == null) {
             return;
         }
-        SelectNewNotes(currentMapDifficulty.notes);
+        currentMapDifficulty.notes.Select(currentMapDifficulty.selectedNotes.Add);
+        parent.gridController.HighlightAllNotes();
+        RecalculateMapStats();
     }
     public void SelectNewNotes(IEnumerable<Note> notes, bool updateMapStats = true) {
         UnselectAllNotes(false);
@@ -400,7 +411,7 @@ public class MapEditor : IDisposable {
         if (currentMapDifficulty?.selectedNotes == null) {
             return;
         }
-        parent.gridController.UnhighlightNotes(currentMapDifficulty.selectedNotes);
+        parent.gridController.UnhighlightAllNotes();
         currentMapDifficulty.selectedNotes.Clear();
         if (updateMapStats) {
             RecalculateMapStats();
@@ -410,9 +421,14 @@ public class MapEditor : IDisposable {
         if (currentMapDifficulty == null) {
             return;
         }
-        clipboard.Clear();
-        foreach (var n in currentMapDifficulty.selectedNotes) {
-            clipboard.Add(n);
+        try {
+            var noteSelection = new NoteSelection(this);
+            var clipboardData = new DataObject("Edda_Note_Selection", noteSelection);
+            RagnaRuneString.Version1.RuneStringData runeStringData = noteSelection;
+            clipboardData.SetText(RuneStringSerializer.Serialize(runeStringData, RagnaRuneString.Version.VERSION_1));
+            Clipboard.SetDataObject(clipboardData, true);
+        } catch (Exception ex) {
+            Trace.WriteLine($"WARNING: Failed to copy notes due to an exception: {ex}");
         }
     }
     public void CutSelection() {
@@ -423,18 +439,30 @@ public class MapEditor : IDisposable {
         RemoveNotes(currentMapDifficulty.selectedNotes);
     }
     public void PasteClipboard(double beatOffset, int? colStart) {
-        if (currentMapDifficulty == null || clipboard.Count() == 0) {
+        if (currentMapDifficulty == null) {
             return;
         }
-        // paste notes so that the first note lands on the given beat offset
-        Note clipboardFirst = clipboard.First();
-        double rowOffset = beatOffset - clipboardFirst.beat;
-        int colOffset = colStart == null ? 0 : (int)colStart - clipboardFirst.col;
-        AddNotes(clipboard
-            .Select(n => new Note(n.beat + rowOffset, n.col + colOffset))
-            // don't paste the note if it goes beyond the duration of the song or overflows on the columns
-            .Where(n => n.beat <= globalBPM * songDuration / 60 && n.col >= 0 && n.col <= 3)
-        );
+
+        NoteSelection? noteSelection = null;
+        var clipboardData = Clipboard.GetDataObject();
+        if (clipboardData == null) return;
+        if (clipboardData.GetDataPresent("Edda_Note_Selection")) {
+            object? data = clipboardData.GetData("Edda_Note_Selection");
+            if (data == null || data is not NoteSelection) return;
+            noteSelection = (NoteSelection)data;
+        } else if (clipboardData.GetDataPresent(DataFormats.Text)) {
+            string clipboardText = (clipboardData.GetData(DataFormats.Text) as string)!;
+            try {
+                noteSelection = new NoteSelection(RuneStringSerializer.DeserializeV1(clipboardText.Trim()));
+            } catch (Exception) {
+                Trace.WriteLine($"DEBUG: tried to paste invalid rune string: \"{clipboardText}\"");
+                return;
+            }
+        }
+
+        if (noteSelection == null || noteSelection?.notes.Count == 0) return;
+
+        AddNotes(noteSelection!.GetPasteNotes(this, beatOffset, colStart));
     }
     public void QuantizeSelection() {
         if (currentMapDifficulty == null) {
@@ -467,21 +495,15 @@ public class MapEditor : IDisposable {
     }
     public BPMChange GetLastBeatChange(double beat) {
         return currentMapDifficulty?.bpmChanges
-            .OrderByDescending(obj => obj.globalBeat)
-            .Where(obj => obj.globalBeat <= beat)
-            .Select(obj => obj)
-            .FirstOrDefault() ?? new BPMChange(0.0, globalBPM, defaultGridDivision);
+            .Where(obj => Helper.DoubleApproxGreaterEqual(beat, obj.globalBeat))
+            .LastOrDefault() ?? new BPMChange(0.0, globalBPM, defaultGridDivision);
     }
     private void ApplyEdit(EditList<Note> e) {
-        foreach (var edit in e.items) {
-            if (edit.isAdd) {
-                AddNotes(edit.item, false);
-            } else {
-                RemoveNotes(edit.item, false);
-            }
-            UnselectAllNotes();
-        }
-
+        var notesToAdd = e.items.Where(edit => edit.isAdd).Select(edit => edit.item).ToList();
+        if (notesToAdd.Count > 0) AddNotes(notesToAdd, false);
+        var notesToRemove = e.items.Where(edit => !edit.isAdd).Select(edit => edit.item).ToList();
+        if (notesToRemove.Count > 0) RemoveNotes(notesToRemove, false);
+        UnselectAllNotes();
     }
     public void MirrorSelection() {
         if (currentMapDifficulty == null) {

--- a/Classes/MapEditor/MapEditor.cs
+++ b/Classes/MapEditor/MapEditor.cs
@@ -386,7 +386,9 @@ public class MapEditor : IDisposable {
         if (currentMapDifficulty == null) {
             return;
         }
-        currentMapDifficulty.notes.Select(currentMapDifficulty.selectedNotes.Add);
+        foreach (var note in currentMapDifficulty.notes) {
+            currentMapDifficulty.selectedNotes.Add(note);
+        }
         parent.gridController.HighlightAllNotes();
         RecalculateMapStats();
     }

--- a/Classes/MapEditor/Note/Note.cs
+++ b/Classes/MapEditor/Note/Note.cs
@@ -1,31 +1,31 @@
 ﻿using System;
 
-public class Note : IComparable, IEquatable<Note> {
-    public double beat;
-    public int col;
-    public Note(double beat, int col) {
-        this.beat = beat;
-        this.col = col;
-    }
-    public Note() : this(0, 0) { }
+namespace Edda.Classes.MapEditorNS.NoteNS {
+    [Serializable]
+    public class Note(double beat, int col) : IComparable, IEquatable<Note> {
+        public double beat = beat;
+        public int col = col;
 
-    public int CompareTo(object obj) {
-        if (!(obj is Note n)) {
-            throw new Exception();
-        }
-        if (this.Equals(n)) {
-            return 0;
-        }
-        if (Helper.DoubleApproxGreater(this.beat, n.beat)) {
-            return 1;
-        }
-        if (Helper.DoubleApproxEqual(n.beat, this.beat) && this.col > n.col) {
-            return 1;
-        }
-        return -1;
-    }
+        public Note() : this(0, 0) { }
 
-    public bool Equals(Note n) {
-        return Helper.DoubleApproxEqual(n.beat, this.beat) && n.col == this.col;
+        public int CompareTo(object obj) {
+            if (obj is not Note n) {
+                throw new Exception();
+            }
+            if (Equals(n)) {
+                return 0;
+            }
+            if (Helper.DoubleApproxGreater(beat, n.beat)) {
+                return 1;
+            }
+            if (Helper.DoubleApproxEqual(n.beat, beat) && col > n.col) {
+                return 1;
+            }
+            return -1;
+        }
+
+        public override bool Equals(object obj) => obj is Note n && Equals(n);
+        public override int GetHashCode() => HashCode.Combine(Math.Round(beat, 4), col);
+        public bool Equals(Note n) => Helper.DoubleApproxEqual(n.beat, beat) && n.col == col;
     }
 }

--- a/Classes/MapEditor/Note/NoteSelection.cs
+++ b/Classes/MapEditor/Note/NoteSelection.cs
@@ -102,7 +102,7 @@ namespace Edda.Classes.MapEditorNS.NoteNS {
                 var scaleFactor = editor.GetGridLength(currentEditorBeatChange.BPM, 1) / (notesGlobalBPM / noteBPM);
                 var projectedBeat = (note.beat - lastNoteBeat) * scaleFactor + beatOffset;
                 var projectedEditorBeatChange = editor.GetLastBeatChange(projectedBeat);
-                while (projectedEditorBeatChange != currentEditorBeatChange) {
+                while (!projectedEditorBeatChange.Equals(currentEditorBeatChange)) {
                     // We went through (potentially several) BPM changes between notes, so we need to first re-align offsets to the last one before projected note placement
                     foreach (var bpmChange in editor.currentMapDifficulty.bpmChanges.GetViewBetween(currentEditorBeatChange, projectedEditorBeatChange)) {
                         lastNoteBeat += (bpmChange.globalBeat - beatOffset) / editor.GetGridLength(currentEditorBeatChange.BPM, 1);

--- a/Classes/MapEditor/Note/NoteSelection.cs
+++ b/Classes/MapEditor/Note/NoteSelection.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using static Edda.Const.Editor;
+
+namespace Edda.Classes.MapEditorNS.NoteNS {
+    [Serializable]
+    public class NoteSelection {
+        public SortedSet<Note> notes = [];
+        public SortedSet<BPMChange> bpmChanges = [];
+
+        public NoteSelection(MapEditor editor) {
+            notes = editor.currentMapDifficulty.selectedNotes;
+            bpmChanges = new(
+                editor.currentMapDifficulty.bpmChanges
+                    .Append(new BPMChange(0, editor.GlobalBPM, 4)) // RagnaRuneString represents global BPM as a BPM change with timing 0.
+            );
+        }
+
+        public NoteSelection(RagnaRuneString.Version1.RuneStringData runeStringData) {
+            notes = new SortedSet<Note>(runeStringData.runes.Select(r => new Note(r.time, r.lineIndex)));
+            bpmChanges = new SortedSet<BPMChange>(runeStringData.bpmChanges.Select(b => new BPMChange(b.startTime, b.bpm, 4)));
+        }
+
+        public static implicit operator RagnaRuneString.Version1.RuneStringData(NoteSelection noteSelection) {
+            return new RagnaRuneString.Version1.RuneStringData(
+                runes: noteSelection.notes.Select(n => new RagnaRuneString.Version1.Rune(n.beat, n.col)),
+                bpmChanges: noteSelection.bpmChanges.Select(b => new RagnaRuneString.Version1.BPMChange(b.BPM, b.globalBeat))
+            );
+        }
+
+        public IEnumerable<Note> GetPasteNotes(MapEditor editor, double beatOffset, int? colStart) {
+            return (editor.NotePasteBehavior switch {
+                NotePasteBehavior.AlignToGlobalBeat => GetPasteNotesAlignToGlobalBeat(beatOffset, colStart),
+                NotePasteBehavior.AlignToFirstNoteBPM => GetPasteNotesAlignToFirstNoteBPM(editor, beatOffset, colStart),
+                NotePasteBehavior.AlignToNoteBPM => GetPasteNotesAlignToNoteBPM(editor, beatOffset, colStart),
+                _ => GetPasteNotesAlignToNoteBPM(editor, beatOffset, colStart)
+            })
+                // don't paste the note if it goes beyond the duration of the song or overflows on the columns
+                .Where(n => n.beat <= editor.GlobalBPM * editor.SongDuration / 60 && n.col >= 0 && n.col <= 3);
+        }
+
+        /// <summary>
+        /// Paste notes as-if they were copied from the same global BPM and disregard any BPM changes.
+        /// </summary>
+        /// <example>
+        /// [Note(0.25, 0), Note(0.5, 1), Note(0.75, 2), Note(1, 3)] copied from a song with 140 BPM.
+        /// Pasting into a song with 120 BPM at global beat offset 51.5, they'll be added as new notes:
+        /// [Note(51.5, 0), Note(51.75, 1), Note(52, 2), Note(52.25, 3)]
+        /// </example>
+        /// <param name="beatOffset">global beat offset to start the pasting</param>
+        /// <param name="colStart">column offset to start the pasting</param>
+        /// <returns>collection of notes to paste</returns>
+        private IEnumerable<Note> GetPasteNotesAlignToGlobalBeat(double beatOffset, int? colStart) {
+            Note firstNote = notes.First();
+            double rowOffset = beatOffset - firstNote.beat;
+            int colOffset = colStart == null ? 0 : (int)colStart - firstNote.col;
+            return notes.Select(n => new Note(n.beat + rowOffset, n.col + colOffset));
+        }
+
+        /// <summary>
+        /// Paste notes only scaling by a factor based on the first pasted note BPM and mouse position BPM.
+        /// </summary>
+        /// <example>
+        /// [Note(10.25, 0), Note(10.5, 1), Note(10.75, 2), Note(11, 3)] copied from a song with 140 BPM, with BPM change to 70 at global beat 10.
+        /// Pasting into a song with 120 BPM at global beat offset 51.5, they'll be added as new notes:
+        /// [Note(51.5, 0), Note(52, 1), Note(52.5, 2), Note(53, 3)]
+        /// </example>
+        /// <param name="editor">map editor</param>
+        /// <param name="beatOffset">global beat offset to start the pasting</param>
+        /// <param name="colStart">column offset to start the pasting</param>
+        /// <returns>collection of notes to paste</returns>
+        private IEnumerable<Note> GetPasteNotesAlignToFirstNoteBPM(MapEditor editor, double beatOffset, int? colStart) {
+            Note firstNote = notes.First();
+            int colOffset = colStart == null ? 0 : (int)colStart - firstNote.col;
+            var notesGlobalBPM = GetLastBeatChange(0)?.BPM ?? editor.GlobalBPM;
+            var firstNoteBPM = GetLastBeatChange(firstNote.beat)?.BPM ?? notesGlobalBPM;
+            var scaleFactor = editor.GetGridLength(editor.GetLastBeatChange(beatOffset).BPM, 1) / (notesGlobalBPM / firstNoteBPM);
+            return notes.Select(n => new Note((n.beat - firstNote.beat) * scaleFactor + beatOffset, n.col + colOffset));
+        }
+
+        /// <summary>
+        /// Paste notes by aligning each note timing based on the BPM changes in the pasted notes BPM changes in the editor where the notes are pasted.
+        /// </summary>
+        /// <example>
+        /// [Note(10.25, 0), Note(10.5, 1), Note(10.75, 2), Note(11, 3)] copied from a song with 140 BPM, with BPM changes to 70 at global beat 10 and to 140 at global beat 10.5.
+        /// Pasting into a song with 120 BPM at global beat offset 51.5 and a BPM change to 240 at global beat 52.25, they'll be added as new notes:
+        /// [Note(51.5, 0), Note(52, 1), Note(52.25, 2), Note(52.375, 3)]
+        /// </example>
+        /// <param name="editor">map editor</param>
+        /// <param name="beatOffset">global beat offset to start the pasting</param>
+        /// <param name="colStart">column offset to start the pasting</param>
+        /// <returns>collection of notes to paste</returns>
+        private IEnumerable<Note> GetPasteNotesAlignToNoteBPM(MapEditor editor, double beatOffset, int? colStart) {
+            Note firstNote = notes.First();
+            int colOffset = colStart == null ? 0 : (int)colStart - firstNote.col;
+            var notesGlobalBPM = GetLastBeatChange(0)?.BPM ?? editor.GlobalBPM;
+            var currentEditorBeatChange = editor.GetLastBeatChange(beatOffset);
+            double lastNoteBeat = firstNote.beat;
+            foreach (var note in notes) {
+                var noteBPM = GetLastBeatChange(note.beat)?.BPM ?? notesGlobalBPM;
+                var scaleFactor = editor.GetGridLength(currentEditorBeatChange.BPM, 1) / (notesGlobalBPM / noteBPM);
+                var projectedBeat = (note.beat - lastNoteBeat) * scaleFactor + beatOffset;
+                var projectedEditorBeatChange = editor.GetLastBeatChange(projectedBeat);
+                while (projectedEditorBeatChange != currentEditorBeatChange) {
+                    // We went through (potentially several) BPM changes between notes, so we need to first re-align offsets to the last one before projected note placement
+                    foreach (var bpmChange in editor.currentMapDifficulty.bpmChanges.GetViewBetween(currentEditorBeatChange, projectedEditorBeatChange)) {
+                        lastNoteBeat += (bpmChange.globalBeat - beatOffset) / editor.GetGridLength(currentEditorBeatChange.BPM, 1);
+                        beatOffset = bpmChange.globalBeat;
+                        currentEditorBeatChange = bpmChange;
+                    }
+                    // Recalculate projected beat
+                    scaleFactor = editor.GetGridLength(currentEditorBeatChange.BPM, 1) / (notesGlobalBPM / noteBPM);
+                    projectedBeat = (note.beat - lastNoteBeat) * scaleFactor + beatOffset;
+                    projectedEditorBeatChange = editor.GetLastBeatChange(projectedBeat);
+                }
+                yield return new Note(projectedBeat, note.col + colOffset);
+                beatOffset = projectedBeat;
+                currentEditorBeatChange = projectedEditorBeatChange;
+                lastNoteBeat = note.beat;
+            }
+        }
+
+        private BPMChange? GetLastBeatChange(double beat) {
+            return bpmChanges
+                .Where(obj => Helper.DoubleApproxGreaterEqual(beat, obj.globalBeat))
+                .LastOrDefault();
+        }
+    }
+}

--- a/Classes/MapEditor/Note/NoteSelection.cs
+++ b/Classes/MapEditor/Note/NoteSelection.cs
@@ -13,7 +13,7 @@ namespace Edda.Classes.MapEditorNS.NoteNS {
             notes = editor.currentMapDifficulty.selectedNotes;
             bpmChanges = new(
                 editor.currentMapDifficulty.bpmChanges
-                    .Append(new BPMChange(0, editor.GlobalBPM, 4)) // RagnaRuneString represents global BPM as a BPM change with timing 0.
+                    .Append(new BPMChange(-1, editor.GlobalBPM, 4)) // RagnaRuneString represents global BPM as a BPM change with timing -1.
             );
         }
 
@@ -73,7 +73,7 @@ namespace Edda.Classes.MapEditorNS.NoteNS {
         private IEnumerable<Note> GetPasteNotesAlignToFirstNoteBPM(MapEditor editor, double beatOffset, int? colStart) {
             Note firstNote = notes.First();
             int colOffset = colStart == null ? 0 : (int)colStart - firstNote.col;
-            var notesGlobalBPM = GetLastBeatChange(0)?.BPM ?? editor.GlobalBPM;
+            var notesGlobalBPM = GetLastBeatChange(-1)?.BPM ?? editor.GlobalBPM;
             var firstNoteBPM = GetLastBeatChange(firstNote.beat)?.BPM ?? notesGlobalBPM;
             var scaleFactor = editor.GetGridLength(editor.GetLastBeatChange(beatOffset).BPM, 1) / (notesGlobalBPM / firstNoteBPM);
             return notes.Select(n => new Note((n.beat - firstNote.beat) * scaleFactor + beatOffset, n.col + colOffset));
@@ -94,7 +94,7 @@ namespace Edda.Classes.MapEditorNS.NoteNS {
         private IEnumerable<Note> GetPasteNotesAlignToNoteBPM(MapEditor editor, double beatOffset, int? colStart) {
             Note firstNote = notes.First();
             int colOffset = colStart == null ? 0 : (int)colStart - firstNote.col;
-            var notesGlobalBPM = GetLastBeatChange(0)?.BPM ?? editor.GlobalBPM;
+            var notesGlobalBPM = GetLastBeatChange(-1)?.BPM ?? editor.GlobalBPM;
             var currentEditorBeatChange = editor.GetLastBeatChange(beatOffset);
             double lastNoteBeat = firstNote.beat;
             foreach (var note in notes) {

--- a/Classes/MapEditor/RagnarockMap.cs
+++ b/Classes/MapEditor/RagnarockMap.cs
@@ -1,4 +1,6 @@
 ﻿using Edda;
+using Edda.Classes.MapEditorNS;
+using Edda.Classes.MapEditorNS.NoteNS;
 using Edda.Const;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/Classes/MapEditor/Stats/DifficultyPredictorMelchior.cs
+++ b/Classes/MapEditor/Stats/DifficultyPredictorMelchior.cs
@@ -1,4 +1,5 @@
-﻿using Edda.Const;
+﻿using Edda.Classes.MapEditorNS.NoteNS;
+using Edda.Const;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Classes/MapEditor/Stats/DifficultyPredictorNytilde.cs
+++ b/Classes/MapEditor/Stats/DifficultyPredictorNytilde.cs
@@ -1,4 +1,5 @@
-﻿using Edda.Const;
+﻿using Edda.Classes.MapEditorNS.NoteNS;
+using Edda.Const;
 using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
 using System;

--- a/Classes/MapEditor/Stats/DifficultyPredictorPKBeam.cs
+++ b/Classes/MapEditor/Stats/DifficultyPredictorPKBeam.cs
@@ -1,4 +1,5 @@
-﻿using Syncfusion.PMML;
+﻿using Edda.Classes.MapEditorNS.NoteNS;
+using Syncfusion.PMML;
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/Classes/MapEditor/Stats/MapStats.cs
+++ b/Classes/MapEditor/Stats/MapStats.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Edda.Classes.MapEditorNS.NoteNS;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/RagnarockEditor.csproj
+++ b/RagnarockEditor.csproj
@@ -96,6 +96,7 @@
     </PackageReference>
     <PackageReference Include="NAudio" Version="2.1.0" />
     <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
+    <PackageReference Include="RagnaRuneString" Version="1.0.2" />
     <PackageReference Include="SoundTouch.Net.NAudioSupport.Core" Version="2.3.2" />
     <PackageReference Include="Spectrogram" Version="1.6.1" />
     <PackageReference Include="Syncfusion.PMML.Net.Core" Version="20.4.0.43" />

--- a/Windows/ChangeBPMWindow.xaml.cs
+++ b/Windows/ChangeBPMWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Edda.Const;
+﻿using Edda.Classes.MapEditorNS;
+using Edda.Const;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Windows/MainWindow.UIControls.cs
+++ b/Windows/MainWindow.UIControls.cs
@@ -1,4 +1,5 @@
-﻿using Edda.Const;
+﻿using Edda.Classes.MapEditorNS;
+using Edda.Const;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -340,15 +341,8 @@ namespace Edda {
                 int.TryParse(txtGridDivision.Text, out currentBeatDivision);
                 txtGridDivision.Text = ((int)Helper.DoubleRangeTruncate(currentBeatDivision + delta, 1, Editor.GridDivisionMax)).ToString();
             } else {
-                var currentBpmChange = mapEditor.currentMapDifficulty.bpmChanges
-                    .Where(bpmChange => bpmChange.globalBeat < pos)
-                    .OrderByDescending(bpmChange => bpmChange.globalBeat)
-                    .FirstOrDefault();
-
-                if (currentBpmChange != null) {
-                    currentBpmChange.gridDivision = (int)Helper.DoubleRangeTruncate(currentBpmChange.gridDivision + delta, 1, Editor.GridDivisionMax);
-                    gridController.DrawGrid(false);
-                }
+                lastChange.gridDivision = (int)Helper.DoubleRangeTruncate(lastChange.gridDivision + delta, 1, Editor.GridDivisionMax);
+                gridController.DrawGrid(false);
             }
             e.Handled = true; // Mark tunneling event as handled to prevent scrolling on the grid while changing the division.
         }

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Edda.Classes.MapEditorNS.Stats;
+﻿using Edda.Classes.MapEditorNS.NoteNS;
+using Edda.Classes.MapEditorNS.Stats;
 using Edda.Const;
 using Microsoft.WindowsAPICodePack.Dialogs;
 using NAudio.CoreAudioApi;
@@ -888,6 +889,10 @@ namespace Edda {
             SetDiscordRPC(userSettings.GetBoolForKey(UserSettingsKey.EnableDiscordRPC));
             autosaveTimer.Enabled = userSettings.GetBoolForKey(UserSettingsKey.EnableAutosave);
 
+        }
+
+        internal string GetUserSetting(string key) {
+            return userSettings.GetValueForKey(key);
         }
 
         // song cover image

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -91,11 +91,11 @@
                             </StackPanel>
                         </Border>
 
-                        <Border Grid.Row="4" Grid.Column="0">
+                        <Border Grid.Row="5" Grid.Column="0">
                             <TextBlock FontSize="10" VerticalAlignment="Center">Note Paste Behavior</TextBlock>
                         </Border>
 
-                        <Border Grid.Row="4" Grid.Column="1">
+                        <Border Grid.Row="5" Grid.Column="1">
                             <ComboBox x:Name="comboNotePasteBehavior" DisplayMemberPath="Label" SelectionChanged="ComboNotePasteBehavior_SelectionChanged" VerticalAlignment="Center"/>
                         </Border>
 

--- a/Windows/SettingsWindow.xaml
+++ b/Windows/SettingsWindow.xaml
@@ -81,6 +81,14 @@
                             </StackPanel>
                         </Border>
 
+                        <Border Grid.Row="4" Grid.Column="0">
+                            <TextBlock FontSize="10" VerticalAlignment="Center">Note Paste Behavior</TextBlock>
+                        </Border>
+
+                        <Border Grid.Row="4" Grid.Column="1">
+                            <ComboBox x:Name="comboNotePasteBehavior" DisplayMemberPath="Label" SelectionChanged="ComboNotePasteBehavior_SelectionChanged" VerticalAlignment="Center"/>
+                        </Border>
+
                     </Grid>
                     <Label Margin="0 10 0 0" Padding="10 5" FontWeight="Bold" FontSize="16" FontFamily="Bahnschrift">Audio Playback</Label>
                     <Grid Margin="15 0 5 0" VerticalAlignment="Center">

--- a/Windows/SettingsWindow.xaml.cs
+++ b/Windows/SettingsWindow.xaml.cs
@@ -25,6 +25,7 @@ namespace Edda {
             InitComboDrumSample();
             txtDefaultNoteSpeed.Text = userSettings.GetValueForKey(UserSettingsKey.DefaultNoteSpeed);
             txtDefaultGridSpacing.Text = userSettings.GetValueForKey(UserSettingsKey.DefaultGridSpacing);
+            InitComboNotePasteBehavior();
             txtAudioLatency.Text = userSettings.GetValueForKey(UserSettingsKey.EditorAudioLatency);
             checkPanNotes.IsChecked = userSettings.GetBoolForKey(UserSettingsKey.PanDrumSounds);
             sliderSongVol.Value = float.Parse(userSettings.GetValueForKey(UserSettingsKey.DefaultSongVolume));
@@ -80,6 +81,27 @@ namespace Edda {
                 gridSpacing = prevGridSpacing;
             }
             txtDefaultGridSpacing.Text = gridSpacing.ToString();
+        }
+
+        private void ComboNotePasteBehavior_SelectionChanged(object sender, SelectionChangedEventArgs e) {
+            userSettings.SetValueForKey(UserSettingsKey.NotePasteBehavior, ((NotePasteBehavior)comboNotePasteBehavior.SelectedItem).Value);
+            if (doneInit) {
+                UpdateSettings();
+            }
+        }
+        private void InitComboNotePasteBehavior() {
+            string selectedNotePasteBehavior = userSettings.GetValueForKey(UserSettingsKey.NotePasteBehavior) ?? DefaultUserSettings.NotePasteBehavior;
+            NotePasteBehavior[] notePasteBehaviors = [
+                new(Editor.NotePasteBehavior.AlignToGlobalBeat, "Align to global beat"),
+                new(Editor.NotePasteBehavior.AlignToFirstNoteBPM, "Align to first note BPM"),
+                new(Editor.NotePasteBehavior.AlignToNoteBPM, "Align to all notes BPM")
+            ];
+            foreach (var notePasteBehavior in notePasteBehaviors) {
+                int i = comboNotePasteBehavior.Items.Add(notePasteBehavior);
+                if (notePasteBehavior.Value == selectedNotePasteBehavior) {
+                    comboNotePasteBehavior.SelectedIndex = i;
+                }
+            }
         }
 
         private void ComboPlaybackDevice_SelectionChanged(object sender, SelectionChangedEventArgs e) {
@@ -369,6 +391,11 @@ namespace Edda {
                 this.ID = device.ID;
                 this.Name = device.FriendlyName;
             }
+        }
+
+        class NotePasteBehavior(string value, string label) {
+            public string Value { get; private set; } = value;
+            public string Label { get; private set; } = label;
         }
     }
 }


### PR DESCRIPTION
#133 

I'm very sorry for a large PR - while working on the clipboard, I've also noticed several performance issues and smaller bugs with rune images sometimes showing X wrongly, so I've ended up going a bit too far and fixing them here as well.

## Changelist
1. Implemented native clipboard support for copying and pasting notes, using open source [RagnaRuneString library](https://github.com/Brollyy/RagnaRuneString) by @Brollyy to enable clipboard support outside Edda as well.
2. Implemented three different options when pasting notes, allowing mappers to select how they want the notes to be pasted, depending on source/target BPM.
3. Significantly improved performance of editor actions:
    - highlighting and unhighlightning notes in large bulks
    - highlighting all notes (Ctrl+A) and unhighlightning all notes (Esc)
    - reversing large edit lists (Ctrl+Z)

## Copy/paste

To better illustrate what these changes are mainly about, I'll provide a few examples of how the new code behaves.

1. Go into Edda and select some notes (these ones come from a song with 155 global BPM).
![image](https://github.com/user-attachments/assets/2f3cd462-1a21-4430-a2a1-1af987b86769)
2. `Ctrl+C` to copy the notes into clipboard.
3. `Ctrl+V` somewhere else to paste the notes, just as before, but now it works automatically for:
    - a different map difficulty
    - another Edda window - you can have multiple windows open and copy/paste between them, or copy notes from one song and then open another song and paste them there
    - any text editor - notes will be pasted in RagnaRuneString format (looks similar to Hearthstone deckcodes, e.g. `AAEJ+IsEvJ8EgLMExMYEiNoEzO0EkIEF1JQFmKgFG7kAAAACALDNXpY3sM1e`), which can then be copied and pasted again into Edda seemlessly. This is the main use-case for the library, to enable easy sharing of patterns on Discord or RagnaCustoms. I also have plans in the near future to create a small Discord bot that will generate and post visualizations of these runestrings, so we can stop talking about patterns in ASCII art 😄 

When pasting previously copied notes or a runestring, Edda will now have three modes of how the new notes will be added:

### 1. Align to global beat
This is how the copy/paste worked in Edda until now - you move the global beats of the copied notes by an offset determined by current mouse position and then add them to the map.

Fully inside section with global BPM:
![image](https://github.com/user-attachments/assets/86d566f4-4540-4405-87aa-19ea019a6f22)

Fully inside section with different BPM:
![image](https://github.com/user-attachments/assets/0fca16d5-015c-4e8e-8b2f-b852cad95eb8)

Partially inside both global BPM and different BPM:
![image](https://github.com/user-attachments/assets/7845a689-e6c8-4c38-b5f3-e35656ef37b3)

Partially inside different BPM and then global BPM:
![image](https://github.com/user-attachments/assets/ffe8e50f-dc26-434e-9a96-9e5bea3e2f36)


**Pros**:
- note timing between pasted notes always stays consistent relative to their timing when copied
- aligns notes to grid when pasting notes into a different song with different global BPM

**Cons**:
- if you have timing changes in your song, the notes are not aligned to the grid

### 2. Align to first note BPM
This is very similar to the previous mode, but the timing of all the pasted notes is scaled relative to the BPM from which the first copied note came from, and the BPM at the current mouse position. For example, when copying the pattern above into a different section with 120 BPM, the notes will align to the grid, but that won't be the case if the timing change occurs somewhere after the first pasted note.

Fully inside section with global BPM:
![image](https://github.com/user-attachments/assets/86d566f4-4540-4405-87aa-19ea019a6f22)

Fully inside section with different BPM:
![image](https://github.com/user-attachments/assets/e8b3c6ee-8b39-4fa4-8e24-5904714bee84)

Partially inside both global BPM and different BPM:
![image](https://github.com/user-attachments/assets/0b5b7fd8-74f5-44df-9a68-d9d97240eb1b)

Partially inside different BPM and then global BPM:
![image](https://github.com/user-attachments/assets/fccd97e2-7f91-4632-836b-794d872a8d49)


**Pros**:
- note timing between pasted notes always stays consistent relative to how they "looked" when copied
- aligns notes to grid when pasting notes into a section with any constant BPM, no matter how different it is from global BPM

**Cons**:
- if you paste notes on a border between timing changes, the ones after a timing change won't be aligned to a grid anymore


### 3. Align to all notes BPM (default)
While it's more complicated to explain how this mode work in detail, it's designed to remedy the issue from the previous mode, so that the copied pattern "looks" the same on the grid as it "looked" when it was copied.

Fully inside section with global BPM:
![image](https://github.com/user-attachments/assets/86d566f4-4540-4405-87aa-19ea019a6f22)

Fully inside section with different BPM:
![image](https://github.com/user-attachments/assets/e8b3c6ee-8b39-4fa4-8e24-5904714bee84)

Partially inside both global BPM and different BPM:
![image](https://github.com/user-attachments/assets/9a0bc591-8833-450b-8860-2d344a47e685)

Partially inside different BPM and then global BPM:
![image](https://github.com/user-attachments/assets/985c91f9-ea19-4589-812d-3ac69cafc9a7)


**Pros**:
- aligns notes to grid almost perfectly, no matter what BPM or timing changes are present when copying or pasting notes

**Cons**:
- note timing between pasted notes can be different compared to the copied pattern
- there are still some edgecases, where timing changes that are not placed on the gridlines still cause the notes to misalign from the grid

Before I've implemented these changes, I've run a [poll on Discord channel](https://discord.com/channels/824960946404327450/854026628724031519/1296519987590201474) to see which option would be preferable - this is why the last mode is selected as the new default.

The selected mode can be changed in the settings:
![image](https://github.com/user-attachments/assets/52b8e6c7-07bd-4c01-a7a2-cf285489eac2)
