### PR TITLE
Edda crashes when it cannot find the drum samples

### DIFF
--- a/Classes/Audio/ParallelAudioPlayer.cs
+++ b/Classes/Audio/ParallelAudioPlayer.cs
@@ -3,7 +3,6 @@ using NAudio.CoreAudioApi;
 using NAudio.Wave;
 using NAudio.Wave.SampleProviders;
 using System;
-using System.Diagnostics;
 using System.IO;
 
 public class ParallelAudioPlayer : IDisposable {
@@ -22,19 +21,19 @@ public class ParallelAudioPlayer : IDisposable {
     public bool isPanned { get; set; }
 
     public ParallelAudioPlayer(MMDevice playbackDevice, string basePath, int streams, int desiredLatency, bool isEnabled, bool isPanned, float defaultVolume) {
-        this.lastPlayedStream = 0;
+        lastPlayedStream = 0;
         this.streams = streams;
         this.isEnabled = isEnabled;
         this.isPanned = isPanned;
         this.desiredLatency = desiredLatency;
         this.basePath = basePath;
         this.playbackDevice = playbackDevice;
-        this.uniqueSamples = 0;
-        while (File.Exists(GetFilePath(basePath, this.uniqueSamples + 1))) {
-            this.uniqueSamples++;
+        uniqueSamples = 0;
+        while (File.Exists(GetFilePath(basePath, uniqueSamples + 1))) {
+            uniqueSamples++;
         }
         if (uniqueSamples < 1) {
-            throw new FileNotFoundException();
+            throw new FileNotFoundException($"Couldn't find the file {GetFilePath(basePath, uniqueSamples + 1)}");
         }
         InitAudioOut(defaultVolume);
     }

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -1392,15 +1392,21 @@ namespace Edda {
         private void InitMetronome() {
             var device = playbackDevice;
             if (device != null) {
-                metronome = new ParallelAudioPlayer(
-                    device,
-                    Audio.MetronomeFilename,
-                    Audio.MetronomeStreams,
-                    Audio.WASAPILatencyTarget,
-                    checkMetronome.IsChecked == true,
-                    false,
-                    float.Parse(userSettings.GetValueForKey(UserSettingsKey.DefaultNoteVolume))
-                );
+                try {
+                    metronome = new ParallelAudioPlayer(
+                        device,
+                        Audio.MetronomeFilename,
+                        Audio.MetronomeStreams,
+                        Audio.WASAPILatencyTarget,
+                        checkMetronome.IsChecked == true,
+                        false,
+                        float.Parse(userSettings.GetValueForKey(UserSettingsKey.DefaultNoteVolume))
+                    );
+                } catch (FileNotFoundException ex) {
+                    Trace.TraceError(ex.Message);
+                    MessageBox.Show(this, $"{ex.Message}. Make sure Edda.exe is next to Resources folder and you're starting Edda from the directory where Edda.exe is stored.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    Close();
+                }
                 beatScanner?.SetAudioPlayer(metronome);
             } else {
                 metronome = null;
@@ -1415,14 +1421,20 @@ namespace Edda {
         private void InitDrummer() {
             var device = playbackDevice;
             if (device != null) {
-                drummer = new ParallelAudioPlayer(
-                    device,
-                    userSettings.GetValueForKey(UserSettingsKey.DrumSampleFile),
-                    Audio.NotePlaybackStreams,
-                    Audio.WASAPILatencyTarget,
-                    userSettings.GetBoolForKey(UserSettingsKey.PanDrumSounds),
-                    float.Parse(userSettings.GetValueForKey(Const.UserSettingsKey.DefaultNoteVolume))
-                );
+                try {
+                    drummer = new ParallelAudioPlayer(
+                        device,
+                        userSettings.GetValueForKey(UserSettingsKey.DrumSampleFile),
+                        Audio.NotePlaybackStreams,
+                        Audio.WASAPILatencyTarget,
+                        userSettings.GetBoolForKey(UserSettingsKey.PanDrumSounds),
+                        float.Parse(userSettings.GetValueForKey(Const.UserSettingsKey.DefaultNoteVolume))
+                    );
+                } catch (FileNotFoundException ex) {
+                    Trace.TraceError(ex.Message);
+                    MessageBox.Show(this, $"{ex.Message}. Make sure Edda.exe is next to Resources folder and you're starting Edda from the directory where Edda.exe is stored.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    Close();
+                }
                 drummer.ChangeVolume(sliderDrumVol.Value);
                 noteScanner?.SetAudioPlayer(drummer);
             } else {


### PR DESCRIPTION
Implemented better error handling when Edda is started from incorrect working directory or resource files are missing.

![image](https://github.com/user-attachments/assets/054d86a5-a441-4a22-b36c-c6d0f539d763)
