### PR TITLE
Improve handling of missing _version in beatmap files

### DIFF
--- a/Classes/MapEditor/RagnarockMap.cs
+++ b/Classes/MapEditor/RagnarockMap.cs
@@ -477,7 +477,8 @@ public class RagnarockMap {
     }
     private void ValidateMap(int indx) {
         Dictionary<string, List<JTokenType?>> expectedTypesL1 = new Dictionary<string, List<JTokenType?>> {
-            {"_version",   stringTypes },
+            // The game doesn't actually check for beatmap version - see https://github.com/PKBeam/Edda/issues/143
+            // {"_version",   stringTypes },
             {"_events",    arrayTypes },
             {"_notes",     arrayTypes },
             {"_obstacles", arrayTypes }


### PR DESCRIPTION
#143 
Removed required validation on beatmap version, as Ragnarock doesn't require it, and some maps on RC don't have it.