### PR TITLE
Beats don't match the song speed after changing difficulty

### DIFF
--- a/Classes/Audio/BeatScanner.cs
+++ b/Classes/Audio/BeatScanner.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 public class BeatScanner : AudioScanner {
-    public BeatScanner(ParallelAudioPlayer parallelAudioPlayer) : base(parallelAudioPlayer) {
+    public BeatScanner(ParallelAudioPlayer parallelAudioPlayer, double tempo) : base(parallelAudioPlayer, tempo) {
     }
 
     public void Start(int millisecStart, List<double> beats, double globalBPM) {

--- a/Classes/Audio/NoteScanner.cs
+++ b/Classes/Audio/NoteScanner.cs
@@ -1,15 +1,11 @@
 ﻿using Edda;
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 
 public class NoteScanner : AudioScanner {
     MainWindow caller;
     List<Note> notesPlayed;
     public bool playedLateNote { get; set; }
-    public NoteScanner(MainWindow caller, ParallelAudioPlayer parallelAudioPlayer) : base(parallelAudioPlayer) {
+    public NoteScanner(MainWindow caller, ParallelAudioPlayer parallelAudioPlayer, double tempo) : base(parallelAudioPlayer, tempo) {
         this.caller = caller;
         this.playedLateNote = false;
     }

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -1024,8 +1024,8 @@ namespace Edda {
             mapEditor.SelectDifficulty(indx);
             bool difficultyDirtyState = mapEditor.currentMapDifficulty.needsSave; // Store the "dirty" state of the difficulty map, so we can restore it after UI is initialized.
 
-            noteScanner = new NoteScanner(this, drummer);
-            beatScanner = new BeatScanner(metronome);
+            noteScanner = new NoteScanner(this, drummer, sliderSongTempo.Value);
+            beatScanner = new BeatScanner(metronome, sliderSongTempo.Value);
 
             txtDifficultyNumber.Text = (string)mapEditor.GetMapValue("_difficultyRank", (RagnarockMapDifficulties)indx);
             txtNoteSpeed.Text = (string)mapEditor.GetMapValue("_noteJumpMovementSpeed", (RagnarockMapDifficulties)indx);


### PR DESCRIPTION
#145 
Fixed an issue with the note scanner and beat scanner resetting tempo after changing difficulty.