### PR TITLE
Display notes on navigational waveform

### DIFF
--- a/Classes/Audio/VorbisWaveformGenerator.cs
+++ b/Classes/Audio/VorbisWaveformGenerator.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Windows;
 using System.Windows.Media;
@@ -14,11 +13,17 @@ public class VorbisWaveformGenerator : IDisposable {
 
     private CancellationTokenSource tokenSource;
     private string filePath;
+    private Color color;
     private bool isDrawing;
-    public VorbisWaveformGenerator(string filePath) {
+    public VorbisWaveformGenerator(string filePath, Color color) {
         RecreateTokens();
         this.filePath = filePath;
+        this.color = color;
         this.isDrawing = false;
+    }
+
+    public void ChangeColor(Color color) {
+        this.color = color;
     }
 
     public void Dispose() {
@@ -53,7 +58,7 @@ public class VorbisWaveformGenerator : IDisposable {
         reader.Position = 0;
         DrawingVisual dv = new DrawingVisual();
         using (DrawingContext dc = dv.RenderOpen()) {
-            Pen bluePen = new Pen(new SolidColorBrush(Editor.Waveform.ColourWPF), Editor.Waveform.ThicknessWPF);
+            Pen bluePen = new(new SolidColorBrush(color), Editor.Waveform.ThicknessWPF);
             bluePen.Freeze();
 
             int channels = reader.WaveFormat.Channels;

--- a/Classes/EddaConstants.cs
+++ b/Classes/EddaConstants.cs
@@ -66,6 +66,10 @@ namespace Edda.Const {
         public const bool DifficultyPredictorShowPrecise = false;
         public const bool DifficultyPredictorShowInMapStats = false;
         public const string NotePasteBehavior = Editor.DefaultNotePasteBehavior;
+        public const bool EnableNavWaveform = true;
+        public const bool EnableNavBookmarks = true;
+        public const bool EnableNavBPMChanges = false;
+        public const bool EnableNavNotes = false;
     }
 
     public static class UserSettingsKey {
@@ -95,6 +99,19 @@ namespace Edda.Const {
         public const string DifficultyPredictorShowPrecise = "difficultyPredictorShowPrecise";
         public const string DifficultyPredictorShowInMapStats = "difficultyPredictorShowInMapStats";
         public const string NotePasteBehavior = "notePasteBehavior";
+        public const string EnableNavWaveform = "enableNavWaveform";
+        public const string NavWaveformColor = "navWaveformColor";
+        public const string EnableNavBookmarks = "enableNavBookmarks";
+        public const string NavBookmarkColor = "navBookmarkColor";
+        public const string NavBookmarkNameColor = "navBookmarkNameColor";
+        public const string NavBookmarkShadowOpacity = "navBookmarkShadowOpacity";
+        public const string EnableNavBPMChanges = "enableNavBPMChanges";
+        public const string NavBPMChangeColor = "navBPMChangeColor";
+        public const string NavBPMChangeLabelColor = "navBPMChangeLabelColor";
+        public const string NavBPMChangeShadowOpacity = "navBPMChangeShadowOpacity";
+        public const string EnableNavNotes = "enableNavNotes";
+        public const string NavNoteColor = "navNoteColor";
+        public const string NavSelectedNoteColor = "navSelectedNoteColor";
     }
     public static class Editor {
         // Grid drawing
@@ -155,10 +172,10 @@ namespace Edda.Const {
             public static string DefaultName = "Bookmark";
             public static string Colour => Colors.SkyBlue.ToString();
             public static string NameColour => Colors.SkyBlue.ToString();
-            public static string BackgroundColour => Colors.SkyBlue.ToString();
             public const double Thickness = 1;
             public const double NameSize = 10;
             public const double NamePadding = 1;
+            public const double ShadowOpacity = 0.5;
             public const double Opacity = 1;
         }
         public static class GridBookmark {
@@ -170,7 +187,16 @@ namespace Edda.Const {
             public const double NamePadding = 3;
             public const double Opacity = 0.75;
         }
-        public static class BPMChange {
+        public static class NavBPMChange {
+            public static string Colour => Colors.Violet.ToString();
+            public static string LabelColour => Colors.Violet.ToString();
+            public const double Thickness = 1;
+            public const double LabelSize = 10;
+            public const double LabelPadding = 1;
+            public const double ShadowOpacity = 0.5;
+            public const double Opacity = 1;
+        }
+        public static class GridBPMChange {
             public static string Colour => Colors.MediumPurple.ToString();
             public static string NameColour => Colors.MediumPurple.ToString();
             public static string BackgroundColour => Colors.MediumPurple.ToString();
@@ -178,6 +204,12 @@ namespace Edda.Const {
             public const double NameSize = 11;
             public const double NamePadding = 3;
             public const double Opacity = 0.75;
+        }
+        public static class NavNote {
+            public static string Colour => MediaColor.FromRgb(210, 210, 210).ToString();
+            public static string HighlightColour => Colors.Gold.ToString();
+            public const double Size = 3;
+            public const double ColumnGap = 4;
         }
         public static class Stats {
             public static readonly MediaColor Colour = Colors.Black;

--- a/Classes/MapEditor/MapEditor.cs
+++ b/Classes/MapEditor/MapEditor.cs
@@ -380,7 +380,7 @@ public class MapEditor : IDisposable {
         SelectNotes([n], updateMapStats);
     }
     public void SelectNotes(IEnumerable<Note> notes, bool updateMapStats = true) {
-        var selectNotes = notes.Where(n => currentMapDifficulty?.selectedNotes?.Add(n) == true);
+        var selectNotes = notes.Where(n => currentMapDifficulty?.selectedNotes?.Add(n) == true).ToList();
         parent.gridController.HighlightNotes(selectNotes);
         parent.gridController.HighlightNavNotes(selectNotes);
         if (updateMapStats) {

--- a/Classes/MapEditor/MapEditor.cs
+++ b/Classes/MapEditor/MapEditor.cs
@@ -286,6 +286,7 @@ public class MapEditor : IDisposable {
         // note: by drawing this note out of order, it is inconsistently layered with other notes.
         //       should we take the performance hit of redrawing the entire grid for visual consistency?
         parent.gridController.DrawNotes(drawNotes);
+        parent.gridController.DrawNavNotes(drawNotes);
 
         if (updateHistory) {
             currentMapDifficulty?.editorHistory.Add(new EditList<Note>(true, drawNotes));
@@ -305,12 +306,14 @@ public class MapEditor : IDisposable {
 
         // undraw the added notes
         parent.gridController.UndrawNotes(undrawNotes);
+        parent.gridController.UndrawNavNotes(undrawNotes);
 
         // add new notes
         var drawNotes = newNotes.Where(n => currentMapDifficulty?.notes?.Add(n) == true).ToList();
 
         // draw new notes
         parent.gridController.DrawNotes(drawNotes);
+        parent.gridController.DrawNavNotes(drawNotes);
 
         if (updateHistory) {
             currentMapDifficulty?.editorHistory.Add(new EditList<Note>(false, undrawNotes));
@@ -333,6 +336,7 @@ public class MapEditor : IDisposable {
 
         // undraw the added notes
         parent.gridController.UndrawNotes(noteList);
+        parent.gridController.UndrawNavNotes(noteList);
 
         if (updateHistory) {
             currentMapDifficulty?.editorHistory.Add(new EditList<Note>(false, noteList));
@@ -347,7 +351,7 @@ public class MapEditor : IDisposable {
         RecalculateMapStats();
     }
     public void RemoveNotes(Note n, bool updateHistory = true) {
-        RemoveNotes(new List<Note>() { n }, updateHistory);
+        RemoveNotes([n], updateHistory);
     }
     internal void RemoveNote(Note n) {
         if (currentMapDifficulty?.notes?.Contains(n) == true) {
@@ -373,11 +377,12 @@ public class MapEditor : IDisposable {
         }
     }
     public void SelectNotes(Note n, bool updateMapStats = true) {
-        SelectNotes(new List<Note>() { n }, updateMapStats);
+        SelectNotes([n], updateMapStats);
     }
     public void SelectNotes(IEnumerable<Note> notes, bool updateMapStats = true) {
         var selectNotes = notes.Where(n => currentMapDifficulty?.selectedNotes?.Add(n) == true);
         parent.gridController.HighlightNotes(selectNotes);
+        parent.gridController.HighlightNavNotes(selectNotes);
         if (updateMapStats) {
             RecalculateMapStats();
         }
@@ -390,6 +395,7 @@ public class MapEditor : IDisposable {
             currentMapDifficulty.selectedNotes.Add(note);
         }
         parent.gridController.HighlightAllNotes();
+        parent.gridController.HighlightAllNavNotes();
         RecalculateMapStats();
     }
     public void SelectNewNotes(IEnumerable<Note> notes, bool updateMapStats = true) {
@@ -404,6 +410,7 @@ public class MapEditor : IDisposable {
             return;
         }
         parent.gridController.UnhighlightNotes(n);
+        parent.gridController.UnhighlightNavNotes(n);
         currentMapDifficulty.selectedNotes.Remove(n);
         if (updateMapStats) {
             RecalculateMapStats();
@@ -414,6 +421,7 @@ public class MapEditor : IDisposable {
             return;
         }
         parent.gridController.UnhighlightAllNotes();
+        parent.gridController.UnhighlightAllNavNotes();
         currentMapDifficulty.selectedNotes.Clear();
         if (updateMapStats) {
             RecalculateMapStats();

--- a/Classes/UI/EditorGridController.cs
+++ b/Classes/UI/EditorGridController.cs
@@ -41,8 +41,11 @@ public class EditorGridController : IDisposable {
     Image[] imgSpectrogramChunks;
     Grid editorMarginGrid;
     Canvas canvasNavInputBox;
+    Canvas canvasNavNotes;
     Canvas canvasBookmarks;
     Canvas canvasBookmarkLabels;
+    Canvas canvasTimingChanges;
+    Canvas canvasTimingChangeLabels;
     Line lineSongMouseover;
 
     // dispatcher of the main application UI thread
@@ -181,8 +184,11 @@ public class EditorGridController : IDisposable {
         StackPanel panelSpectrogram,
         Grid editorMarginGrid,
         Canvas canvasNavInputBox,
+        Canvas canvasNavNotes,
         Canvas canvasBookmarks,
         Canvas canvasBookmarkLabels,
+        Canvas canvasTimingChanges,
+        Canvas canvasTimingChangeLabels,
         Line lineSongMouseover
     ) {
         this.parentWindow = parentWindow;
@@ -197,8 +203,11 @@ public class EditorGridController : IDisposable {
         this.panelSpectrogram = panelSpectrogram;
         this.editorMarginGrid = editorMarginGrid;
         this.canvasNavInputBox = canvasNavInputBox;
+        this.canvasNavNotes = canvasNavNotes;
         this.canvasBookmarks = canvasBookmarks;
         this.canvasBookmarkLabels = canvasBookmarkLabels;
+        this.canvasTimingChanges = canvasTimingChanges;
+        this.canvasTimingChangeLabels = canvasTimingChangeLabels;
         this.lineSongMouseover = lineSongMouseover;
 
         dispatcher = parentWindow.Dispatcher;
@@ -263,8 +272,11 @@ public class EditorGridController : IDisposable {
         imgSpectrogramChunks = null;
         editorMarginGrid = null;
         canvasNavInputBox = null;
+        canvasNavNotes = null;
         canvasBookmarks = null;
         canvasBookmarkLabels = null;
+        canvasTimingChanges = null;
+        canvasTimingChangeLabels = null;
         lineSongMouseover = null;
         dispatcher = null;
         dragSelectBorder = null;
@@ -312,8 +324,8 @@ public class EditorGridController : IDisposable {
     // waveform drawing
     public void InitWaveforms(string songPath) {
         audioSpectrogram = new VorbisSpectrogramGenerator(songPath, spectrogramCache, spectrogramType, spectrogramQuality, spectrogramFrequency, spectrogramColormap, spectrogramFlipped);
-        audioWaveform = new VorbisWaveformGenerator(songPath);
-        navWaveform = new VorbisWaveformGenerator(songPath);
+        audioWaveform = new VorbisWaveformGenerator(songPath, Editor.Waveform.ColourWPF);
+        navWaveform = new VorbisWaveformGenerator(songPath, (MediaColor)(ColorConverter.ConvertFromString(parentWindow.GetUserSetting(UserSettingsKey.NavWaveformColor)) ?? Editor.Waveform.ColourWPF));
     }
     public void RefreshSpectrogramWaveform() {
         audioSpectrogram?.InitSettings(spectrogramCache, spectrogramType, spectrogramQuality, spectrogramFrequency, spectrogramColormap, spectrogramFlipped);
@@ -360,6 +372,7 @@ public class EditorGridController : IDisposable {
     internal void DrawNavWaveform() {
         Task.Run(() => {
             DateTime before = DateTime.Now;
+            navWaveform.ChangeColor((MediaColor)(ColorConverter.ConvertFromString(parentWindow.GetUserSetting(UserSettingsKey.NavWaveformColor)) ?? Editor.Waveform.ColourWPF));
             ImageSource bmp = navWaveform.Draw(borderNavWaveform.ActualHeight, colWaveformVertical.ActualWidth);
             Trace.WriteLine($"INFO: Drew nav waveform in {(DateTime.Now - before).TotalSeconds} sec");
 
@@ -467,8 +480,11 @@ public class EditorGridController : IDisposable {
 
         // then draw the notes
         noteCanvas.Children.Clear();
+        canvasNavNotes.Children.Clear();
         DrawNotes(mapEditor.currentMapDifficulty.notes);
+        DrawNavNotes(mapEditor.currentMapDifficulty.notes);
         HighlightNotes(mapEditor.currentMapDifficulty.selectedNotes);
+        HighlightNavNotes(mapEditor.currentMapDifficulty.selectedNotes);
 
         // including the mouseover preview note
         imgPreviewNote.Width = unitLength;
@@ -484,6 +500,7 @@ public class EditorGridController : IDisposable {
         DrawBookmarks();
         DrawNavBookmarks();
         DrawBPMChanges();
+        DrawNavBPMChanges();
 
         Trace.WriteLine($"INFO: Redrew editor grid in {(DateTime.Now - start).TotalSeconds} seconds.");
     }
@@ -631,11 +648,11 @@ public class EditorGridController : IDisposable {
         Label makeBPMChangeLabel(string content) {
             var label = new Label();
             label.Foreground = Brushes.White;
-            label.Background = (SolidColorBrush)new BrushConverter().ConvertFrom(Editor.BPMChange.NameColour);
-            label.Background.Opacity = Editor.BPMChange.Opacity;
+            label.Background = (SolidColorBrush)new BrushConverter().ConvertFrom(Editor.GridBPMChange.NameColour);
+            label.Background.Opacity = Editor.GridBPMChange.Opacity;
             label.Content = content;
-            label.FontSize = Editor.BPMChange.NameSize;
-            label.Padding = new Thickness(Editor.BPMChange.NamePadding);
+            label.FontSize = Editor.GridBPMChange.NameSize;
+            label.Padding = new Thickness(Editor.GridBPMChange.NamePadding);
             label.FontWeight = FontWeights.Bold;
             label.Opacity = 1.0;
             label.Cursor = Cursors.Hand;
@@ -647,9 +664,9 @@ public class EditorGridController : IDisposable {
             Canvas bpmChangeFlagCanvas = new();
 
             var line = MakeLine(EditorGrid.ActualWidth / 2, unitLength * b.globalBeat);
-            line.Stroke = (SolidColorBrush)new BrushConverter().ConvertFrom(Editor.BPMChange.Colour);
-            line.StrokeThickness = Editor.BPMChange.Thickness;
-            line.Opacity = Editor.BPMChange.Opacity;
+            line.Stroke = (SolidColorBrush)new BrushConverter().ConvertFrom(Editor.GridBPMChange.Colour);
+            line.StrokeThickness = Editor.GridBPMChange.Thickness;
+            line.Opacity = Editor.GridBPMChange.Opacity;
             Canvas.SetBottom(line, 0);
             bpmChangeCanvas.Children.Add(line);
 
@@ -658,7 +675,7 @@ public class EditorGridController : IDisposable {
                 isEditingMarker = true;
                 var txtBox = new TextBox();
                 txtBox.Text = b.gridDivision.ToString();
-                txtBox.FontSize = Editor.BPMChange.NameSize;
+                txtBox.FontSize = Editor.GridBPMChange.NameSize;
                 Canvas.SetLeft(txtBox, 12);
                 Canvas.SetBottom(txtBox, line.StrokeThickness + 2);
                 txtBox.LostKeyboardFocus += new KeyboardFocusChangedEventHandler((src, e) => {
@@ -693,7 +710,7 @@ public class EditorGridController : IDisposable {
                 isEditingMarker = true;
                 var txtBox = new TextBox();
                 txtBox.Text = b.BPM.ToString();
-                txtBox.FontSize = Editor.BPMChange.NameSize;
+                txtBox.FontSize = Editor.GridBPMChange.NameSize;
                 Canvas.SetLeft(txtBox, 2);
                 Canvas.SetBottom(txtBox, line.StrokeThickness + 22);
                 txtBox.LostKeyboardFocus += new KeyboardFocusChangedEventHandler((src, e) => {
@@ -762,15 +779,36 @@ public class EditorGridController : IDisposable {
         }
         canvasBookmarks.Children.Clear();
         canvasBookmarkLabels.Children.Clear();
+        var bookmarkBrush = (SolidColorBrush)new BrushConverter().ConvertFrom(parentWindow.GetUserSetting(UserSettingsKey.NavBookmarkColor) ?? Editor.NavBookmark.Colour);
         foreach (Bookmark b in mapEditor.currentMapDifficulty.bookmarks) {
             var l = MakeLine(borderNavWaveform.ActualWidth, borderNavWaveform.ActualHeight * (1 - 60000 * b.beat / (mapEditor.GlobalBPM * parentWindow.songTotalTimeInSeconds.Value * 1000)));
-            l.Stroke = (SolidColorBrush)new BrushConverter().ConvertFrom(Editor.NavBookmark.Colour);
+            l.Stroke = bookmarkBrush;
             l.StrokeThickness = Editor.NavBookmark.Thickness;
             l.Opacity = Editor.NavBookmark.Opacity;
             canvasBookmarks.Children.Add(l);
 
             var txtBlock = CreateBookmarkLabel(b);
             canvasBookmarkLabels.Children.Add(txtBlock);
+        }
+    }
+
+    internal void DrawNavBPMChanges() {
+        if (!parentWindow.songTotalTimeInSeconds.HasValue || mapEditor.currentMapDifficulty == null) {
+            return;
+        }
+        canvasTimingChanges.Children.Clear();
+        canvasTimingChangeLabels.Children.Clear();
+        var bpmChangeBrush = (SolidColorBrush)new BrushConverter().ConvertFrom(parentWindow.GetUserSetting(UserSettingsKey.NavBPMChangeColor) ?? Editor.NavBPMChange.Colour);
+        foreach (BPMChange b in mapEditor.currentMapDifficulty.bpmChanges) {
+            var l = MakeLine(borderNavWaveform.ActualWidth, borderNavWaveform.ActualHeight * (1 - 60000 * b.globalBeat / (mapEditor.GlobalBPM * parentWindow.songTotalTimeInSeconds.Value * 1000)));
+            l.Stroke = bpmChangeBrush;
+            l.StrokeThickness = Editor.NavBPMChange.Thickness;
+            l.Opacity = Editor.NavBPMChange.Opacity;
+            canvasTimingChanges.Children.Add(l);
+
+            foreach (var txtBlock in CreateBPMChangeLabels(b)) {
+                canvasTimingChangeLabels.Children.Add(txtBlock);
+            }
         }
     }
 
@@ -807,7 +845,28 @@ public class EditorGridController : IDisposable {
         }
     }
     internal void DrawNotes(Note n) {
-        DrawNotes(new List<Note>() { n });
+        DrawNotes([n]);
+    }
+    internal void DrawNavNotes(IEnumerable<Note> notes) {
+        var navNoteFill = (SolidColorBrush)new BrushConverter().ConvertFrom(parentWindow.GetUserSetting(UserSettingsKey.NavNoteColor) ?? Editor.NavNote.Colour);
+
+        foreach (var n in notes) {
+            var navSquare = new Rectangle() {
+                Uid = $"Nav{Helper.UidGenerator(n)}",
+                Width = Editor.NavNote.Size,
+                Height = Editor.NavNote.Size,
+                Fill = navNoteFill
+            };
+
+            var horizontalOffset = (borderNavWaveform.ActualWidth - 4 * Editor.NavNote.Size - 3 * Editor.NavNote.ColumnGap) / 2;
+            var verticalOffset = borderNavWaveform.ActualHeight * (1 - 60000 * n.beat / (mapEditor.GlobalBPM * parentWindow.songTotalTimeInSeconds.Value * 1000));
+            Canvas.SetLeft(navSquare, horizontalOffset + n.col * (Editor.NavNote.ColumnGap + Editor.NavNote.Size));
+            Canvas.SetBottom(navSquare, borderNavWaveform.ActualHeight - verticalOffset - Editor.NavNote.Size / 2);
+            canvasNavNotes.Children.Add(navSquare);
+        }
+    }
+    internal void DrawNavNotes(Note n) {
+        DrawNavNotes([n]);
     }
     internal void UndrawNotes(IEnumerable<Note> notes) {
         foreach (Note n in notes) {
@@ -820,8 +879,22 @@ public class EditorGridController : IDisposable {
             }
         }
     }
+    internal void UndrawNavNotes(IEnumerable<Note> notes) {
+        foreach (Note n in notes) {
+            var nnUid = $"Nav{Helper.UidGenerator(n)}";
+            foreach (UIElement u in canvasNavNotes.Children) {
+                if (u.Uid == nnUid) {
+                    canvasNavNotes.Children.Remove(u);
+                    break;
+                }
+            }
+        }
+    }
     internal void UndrawNotes(Note n) {
-        UndrawNotes(new List<Note>() { n });
+        UndrawNotes([n]);
+    }
+    internal void UndrawNavNotes(Note n) {
+        UndrawNavNotes([n]);
     }
     internal void HighlightNotes(IEnumerable<Note> notes) {
         foreach (Note n in notes) {
@@ -835,8 +908,24 @@ public class EditorGridController : IDisposable {
             }
         }
     }
+    internal void HighlightNavNotes(IEnumerable<Note> notes) {
+        var navNoteFill = (SolidColorBrush)new BrushConverter().ConvertFrom(parentWindow.GetUserSetting(UserSettingsKey.NavSelectedNoteColor) ?? Editor.NavNote.HighlightColour);
+        foreach (Note n in notes) {
+            var navNoteUid = $"Nav{Helper.UidGenerator(n)}";
+            foreach (UIElement e in canvasNavNotes.Children) {
+                if (e.Uid == navNoteUid) {
+                    var navSquare = (Rectangle)e;
+                    navSquare.Fill = navNoteFill;
+                    break; // UID is unique
+                }
+            }
+        }
+    }
     internal void HighlightNotes(Note n) {
-        HighlightNotes(new List<Note>() { n });
+        HighlightNotes([n]);
+    }
+    internal void HighlightNavNotes(Note n) {
+        HighlightNavNotes([n]);
     }
     internal void HighlightAllNotes() {
         foreach (UIElement e in noteCanvas.Children) {
@@ -844,6 +933,13 @@ public class EditorGridController : IDisposable {
             var n = Helper.NoteFromUid(e.Uid);
             if (n == null) continue;
             img.Source = RuneForBeat(n.beat, true);
+        }
+    }
+    internal void HighlightAllNavNotes() {
+        var navNoteFill = (SolidColorBrush)new BrushConverter().ConvertFrom(parentWindow.GetUserSetting(UserSettingsKey.NavSelectedNoteColor) ?? Editor.NavNote.HighlightColour);
+        foreach (UIElement e in canvasNavNotes.Children) {
+            if (e is not Rectangle navSquare) continue;
+            navSquare.Fill = navNoteFill;
         }
     }
     internal void UnhighlightNotes(IEnumerable<Note> notes) {
@@ -858,8 +954,24 @@ public class EditorGridController : IDisposable {
             }
         }
     }
+    internal void UnhighlightNavNotes(IEnumerable<Note> notes) {
+        var navNoteFill = (SolidColorBrush)new BrushConverter().ConvertFrom(parentWindow.GetUserSetting(UserSettingsKey.NavNoteColor) ?? Editor.NavNote.Colour);
+        foreach (Note n in notes) {
+            var navNoteUid = $"Nav${Helper.UidGenerator(n)}";
+            foreach (UIElement e in canvasNavNotes.Children) {
+                if (e.Uid == navNoteUid) {
+                    var navSquare = (Rectangle)e;
+                    navSquare.Fill = navNoteFill;
+                    break; // UID is unique
+                }
+            }
+        }
+    }
     internal void UnhighlightNotes(Note n) {
-        UnhighlightNotes(new List<Note>() { n });
+        UnhighlightNotes([n]);
+    }
+    internal void UnhighlightNavNotes(Note n) {
+        UnhighlightNavNotes([n]);
     }
     internal void UnhighlightAllNotes() {
         foreach (UIElement e in noteCanvas.Children) {
@@ -867,6 +979,13 @@ public class EditorGridController : IDisposable {
             var n = Helper.NoteFromUid(e.Uid);
             if (n == null) continue;
             img.Source = RuneForBeat(n.beat);
+        }
+    }
+    internal void UnhighlightAllNavNotes() {
+        var navNoteFill = (SolidColorBrush)new BrushConverter().ConvertFrom(parentWindow.GetUserSetting(UserSettingsKey.NavNoteColor) ?? Editor.NavNote.Colour);
+        foreach (UIElement e in canvasNavNotes.Children) {
+            if (e is not Rectangle navSquare) continue;
+            navSquare.Fill = navNoteFill;
         }
     }
     internal List<double> GetBeats() {
@@ -1093,22 +1212,33 @@ public class EditorGridController : IDisposable {
         return Helper.BitmapImageForBeat(beatNormalised, highlight);
     }
     private Label CreateBookmarkLabel(Bookmark b) {
+        if (!double.TryParse(parentWindow.GetUserSetting(UserSettingsKey.NavBookmarkShadowOpacity), out var shadowOpacity)) {
+            shadowOpacity = Editor.NavBookmark.ShadowOpacity;
+        }
         var offset = borderNavWaveform.ActualHeight * (1 - 60000 * b.beat / (mapEditor.GlobalBPM * parentWindow.songTotalTimeInSeconds.Value * 1000));
-        var txtBlock = new Label();
-        txtBlock.Foreground = (SolidColorBrush)new BrushConverter().ConvertFrom(Editor.NavBookmark.NameColour);
+        var txtBlock = new TextBlock {
+            Text = b.name,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            MaxWidth = borderNavWaveform.ActualWidth
+        };
+        var label = new Label {
+            Foreground = (SolidColorBrush)new BrushConverter().ConvertFrom(parentWindow.GetUserSetting(UserSettingsKey.NavBookmarkNameColor) ?? Editor.NavBookmark.NameColour),
+            Background = new SolidColorBrush(Colors.Black),
+            Content = txtBlock,
+            FontSize = Editor.NavBookmark.NameSize,
+            Padding = new Thickness(Editor.NavBookmark.NamePadding),
+            FontWeight = FontWeights.Bold,
+            Opacity = Editor.NavBookmark.Opacity,
+            Cursor = Cursors.Hand,
 
-        txtBlock.Content = b.name;
-        txtBlock.FontSize = Editor.NavBookmark.NameSize;
-        txtBlock.Padding = new Thickness(Editor.NavBookmark.NamePadding);
-        txtBlock.FontWeight = FontWeights.Bold;
-        txtBlock.Opacity = Editor.NavBookmark.Opacity;
-        //txtBlock.IsReadOnly = true;
-        txtBlock.Cursor = Cursors.Hand;
-        Canvas.SetBottom(txtBlock, borderNavWaveform.ActualHeight - offset);
-        txtBlock.MouseLeftButtonDown += new MouseButtonEventHandler((src, e) => {
+        };
+        label.Background.Opacity = shadowOpacity;
+        Canvas.SetRight(label, 0);
+        Canvas.SetBottom(label, borderNavWaveform.ActualHeight - offset);
+        label.MouseLeftButtonDown += new MouseButtonEventHandler((src, e) => {
             e.Handled = true;
         });
-        txtBlock.MouseLeftButtonUp += new MouseButtonEventHandler((src, e) => {
+        label.MouseLeftButtonUp += new MouseButtonEventHandler((src, e) => {
             if (parentWindow.ctrlKeyDown) {
                 mapEditor.SelectNotesInBookmark(b);
             } else {
@@ -1117,7 +1247,7 @@ public class EditorGridController : IDisposable {
             }
             e.Handled = true;
         });
-        txtBlock.MouseDown += new MouseButtonEventHandler((src, e) => {
+        label.MouseDown += new MouseButtonEventHandler((src, e) => {
             if (!(e.ChangedButton == MouseButton.Middle)) {
                 return;
             }
@@ -1126,10 +1256,11 @@ public class EditorGridController : IDisposable {
                 mapEditor.RemoveBookmark(b);
             }
         });
-        txtBlock.MouseRightButtonUp += new MouseButtonEventHandler((src, e) => {
+        label.MouseRightButtonUp += new MouseButtonEventHandler((src, e) => {
             var txtBox = new TextBox();
             txtBox.Text = b.name;
             txtBox.FontSize = Editor.NavBookmark.NameSize;
+            Canvas.SetRight(txtBox, 0);
             Canvas.SetBottom(txtBox, borderNavWaveform.ActualHeight - offset);
             txtBox.LostKeyboardFocus += new KeyboardFocusChangedEventHandler((src, e) => {
                 if (txtBox.Text != "") {
@@ -1150,7 +1281,114 @@ public class EditorGridController : IDisposable {
 
             e.Handled = true;
         });
-        return txtBlock;
+        return label;
+    }
+
+    private IEnumerable<Label> CreateBPMChangeLabels(BPMChange b) {
+        if (!double.TryParse(parentWindow.GetUserSetting(UserSettingsKey.NavBPMChangeShadowOpacity), out var shadowOpacity)) {
+            shadowOpacity = Editor.NavBPMChange.ShadowOpacity;
+        }
+        var labelBrush = (SolidColorBrush)new BrushConverter().ConvertFrom(parentWindow.GetUserSetting(UserSettingsKey.NavBPMChangeLabelColor) ?? Editor.NavBPMChange.LabelColour);
+        Label makeBPMChangeLabel(string content) {
+            var label = new Label {
+                Foreground = labelBrush,
+                Background = new SolidColorBrush(Colors.Black),
+                Content = content,
+                FontSize = Editor.NavBPMChange.LabelSize,
+                Padding = new Thickness(Editor.NavBPMChange.LabelPadding),
+                FontWeight = FontWeights.Bold,
+                Opacity = Editor.NavBPMChange.Opacity,
+                Cursor = Cursors.Hand
+            };
+            label.Background.Opacity = shadowOpacity;
+            label.MouseLeftButtonDown += new MouseButtonEventHandler((src, e) => {
+                e.Handled = true;
+            });
+            label.MouseLeftButtonUp += new MouseButtonEventHandler((src, e) => {
+                if (parentWindow.ctrlKeyDown) {
+                    mapEditor.SelectNotesInBPMChange(b);
+                } else {
+                    parentWindow.songSeekPosition = b.globalBeat / mapEditor.GlobalBPM * 60000;
+                    parentWindow.navMouseDown = false;
+                }
+                e.Handled = true;
+            });
+            label.MouseDown += new MouseButtonEventHandler((src, e) => {
+                if (!(e.ChangedButton == MouseButton.Middle)) {
+                    return;
+                }
+                var res = MessageBox.Show(parentWindow, "Are you sure you want to delete this timing change?", "Confirm Deletion", MessageBoxButton.YesNoCancel, MessageBoxImage.Warning);
+                if (res == MessageBoxResult.Yes) {
+                    mapEditor.RemoveBPMChange(b);
+                }
+                e.Handled = true;
+            });
+            return label;
+        }
+        var offset = borderNavWaveform.ActualHeight * (1 - 60000 * b.globalBeat / (mapEditor.GlobalBPM * parentWindow.songTotalTimeInSeconds.Value * 1000));
+        var divLabel = makeBPMChangeLabel($"1/{b.gridDivision} beat");
+        Canvas.SetBottom(divLabel, borderNavWaveform.ActualHeight - offset);
+        divLabel.MouseRightButtonUp += new MouseButtonEventHandler((src, e) => {
+            var txtBox = new TextBox {
+                Text = b.gridDivision.ToString(),
+                FontSize = Editor.NavBPMChange.LabelSize
+            };
+            Canvas.SetLeft(txtBox, Editor.NavBPMChange.LabelPadding + Editor.NavBPMChange.LabelSize);
+            Canvas.SetBottom(txtBox, borderNavWaveform.ActualHeight - offset);
+            txtBox.LostKeyboardFocus += new KeyboardFocusChangedEventHandler((src, e) => {
+                if (int.TryParse(txtBox.Text, out int div) && Helper.DoubleRangeCheck(div, 1, Editor.GridDivisionMax)) {
+                    mapEditor.RemoveBPMChange(b, false);
+                    b.gridDivision = div;
+                    mapEditor.AddBPMChange(b);
+                }
+                canvasNavInputBox.Children.Remove(txtBox);
+            });
+            txtBox.KeyDown += new KeyEventHandler((src, e) => {
+                if (e.Key == Key.Escape || e.Key == Key.Enter) {
+                    Keyboard.ClearFocus();
+                    Keyboard.Focus(parentWindow);
+                }
+            });
+
+            canvasNavInputBox.Children.Add(txtBox);
+            txtBox.Focus();
+            txtBox.SelectAll();
+
+            e.Handled = true;
+        });
+
+        var bpmLabel = makeBPMChangeLabel($"{b.BPM} BPM");
+        Canvas.SetBottom(bpmLabel, borderNavWaveform.ActualHeight - offset + 11);
+        bpmLabel.MouseRightButtonUp += new MouseButtonEventHandler((src, e) => {
+            var txtBox = new TextBox {
+                Text = b.BPM.ToString(),
+                FontSize = Editor.NavBPMChange.LabelSize
+            };
+            Canvas.SetLeft(txtBox, Editor.NavBPMChange.LabelPadding);
+            Canvas.SetBottom(txtBox, borderNavWaveform.ActualHeight - offset + 11);
+            txtBox.LostKeyboardFocus += new KeyboardFocusChangedEventHandler((src, e) => {
+                if (double.TryParse(txtBox.Text, out double BPM) && BPM > 0) {
+                    mapEditor.RemoveBPMChange(b, false);
+                    b.BPM = BPM;
+                    mapEditor.AddBPMChange(b);
+                }
+                canvasNavInputBox.Children.Remove(txtBox);
+            });
+            txtBox.KeyDown += new KeyEventHandler((src, e) => {
+                if (e.Key == Key.Escape || e.Key == Key.Enter) {
+                    Keyboard.ClearFocus();
+                    Keyboard.Focus(parentWindow);
+                }
+            });
+
+            canvasNavInputBox.Children.Add(txtBox);
+            txtBox.Focus();
+            txtBox.SelectAll();
+
+            e.Handled = true;
+        });
+
+        return [divLabel, bpmLabel];
     }
     private int ColForPosition(double pos) {
         // calculate horizontal element

--- a/RagnarockEditor.csproj
+++ b/RagnarockEditor.csproj
@@ -86,6 +86,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DiscordRichPresence" Version="1.1.3.18" />
+    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.6.1" />
     <PackageReference Include="Fano.StepmaniaUtils" Version="1.0.0" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.17.1" />
     <PackageReference Include="Microsoft.WindowsAPICodePack-Shell" Version="1.1.0">

--- a/RagnarockEditor.csproj
+++ b/RagnarockEditor.csproj
@@ -86,7 +86,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="DiscordRichPresence" Version="1.1.3.18" />
-    <PackageReference Include="Extended.Wpf.Toolkit" Version="4.6.1" />
     <PackageReference Include="Fano.StepmaniaUtils" Version="1.0.0" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.17.1" />
     <PackageReference Include="Microsoft.WindowsAPICodePack-Shell" Version="1.1.0">
@@ -97,6 +96,7 @@
     </PackageReference>
     <PackageReference Include="NAudio" Version="2.1.0" />
     <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
+    <PackageReference Include="PixiEditor.ColorPicker" Version="3.4.1" />
     <PackageReference Include="RagnaRuneString" Version="1.0.2" />
     <PackageReference Include="SoundTouch.Net.NAudioSupport.Core" Version="2.3.2" />
     <PackageReference Include="Spectrogram" Version="1.6.1" />

--- a/Windows/CustomizeNavBarWindow.xaml
+++ b/Windows/CustomizeNavBarWindow.xaml
@@ -5,7 +5,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:colorpicker="clr-namespace:ColorPicker;assembly=ColorPicker"
     mc:Ignorable="d"
-    Title="Customize Navigational Bar" Name="Window" Width="450" MinWidth="450" MaxWidth="450" Height="260" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" Background="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}">
+    Title="Customize Navigation Bar" Name="Window" Width="450" MinWidth="450" MaxWidth="450" Height="260" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" Background="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}">
     <Grid>
         <DockPanel>
 

--- a/Windows/CustomizeNavBarWindow.xaml
+++ b/Windows/CustomizeNavBarWindow.xaml
@@ -1,0 +1,160 @@
+﻿<Window x:Class="Edda.CustomizeNavBarWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+    mc:Ignorable="d"
+    Title="Customize Navigational Bar" Name="Window" Width="450" MinWidth="450" MaxWidth="450" Height="260" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" Background="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}">
+    <Grid>
+        <DockPanel>
+
+            <Border DockPanel.Dock="Bottom" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" BorderThickness="0, 1, 0, 0">
+                <Border.Background>
+                    <LinearGradientBrush EndPoint="0.5,1" StartPoint="0.5,0">
+                        <GradientStop Color="{DynamicResource {x:Static SystemColors.ControlLightColorKey}}"/>
+                        <GradientStop Color="{DynamicResource {x:Static SystemColors.ControlDarkColorKey}}" Offset="1"/>
+                    </LinearGradientBrush>
+                </Border.Background>
+                <StackPanel>
+                    <Button x:Name="btnSave" Margin="0 10 10 10" Width="70" HorizontalAlignment="Right" Click="BtnSave_Click">OK</Button>
+                </StackPanel>
+            </Border>
+            <StackPanel Margin="5 5 0 20" HorizontalAlignment="Left">
+                <Grid Margin="15 0 5 0" VerticalAlignment="Center">
+                    <Grid.Resources>
+                        <Style TargetType="Border" >
+                            <Setter Property="Padding" Value="5,5,5,5" />
+                        </Style>
+                    </Grid.Resources>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="95" />
+                        <ColumnDefinition Width="40" />
+                        <ColumnDefinition Width="60" />
+                        <ColumnDefinition Width="60" />
+                        <ColumnDefinition Width="100" />
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+
+                    <Border Grid.Row="0" Grid.Column="1">
+                        <TextBlock FontWeight="DemiBold" HorizontalAlignment="Center" VerticalAlignment="Center">Show</TextBlock>
+                    </Border>
+
+                    <Border Grid.Row="0" Grid.Column="2">
+                        <TextBlock FontWeight="DemiBold" HorizontalAlignment="Center" VerticalAlignment="Center">Color</TextBlock>
+                    </Border>
+
+                    <Border Grid.Row="0" Grid.Column="3">
+                        <TextBlock FontWeight="DemiBold" HorizontalAlignment="Center" VerticalAlignment="Center">Color #2</TextBlock>
+                    </Border>
+
+                    <Border Grid.Row="0" Grid.Column="4">
+                        <TextBlock FontWeight="DemiBold" HorizontalAlignment="Center" VerticalAlignment="Center">Shadow</TextBlock>
+                    </Border>
+
+                    <Border Grid.Row="1" Grid.Column="0">
+                        <TextBlock HorizontalAlignment="Right" VerticalAlignment="Center">Waveform</TextBlock>
+                    </Border>
+
+                    <Border Grid.Row="1" Grid.Column="1">
+                        <CheckBox x:Name="CheckWaveform" HorizontalAlignment="Center" VerticalAlignment="Center" Click="CheckWaveform_Click"/>
+                    </Border>
+
+                    <Border Grid.Row="1" Grid.Column="2">
+                        <xctk:ColorPicker x:Name="ColorWaveform" SelectedColorChanged="ColorWaveform_SelectedColorChanged" LostFocus="ColorWaveform_LostFocus"/>
+                    </Border>
+
+                    <Border Grid.Row="1" Grid.Column="5">
+                        <Button x:Name="ButtonResetWaveform" Width="40" Click="ButtonResetWaveform_Click">Reset</Button>
+                    </Border>
+
+                    <Border Grid.Row="2" Grid.Column="0">
+                        <TextBlock HorizontalAlignment="Right" VerticalAlignment="Center">Bookmarks</TextBlock>
+                    </Border>
+
+                    <Border Grid.Row="2" Grid.Column="1">
+                        <CheckBox x:Name="CheckBookmark" HorizontalAlignment="Center" VerticalAlignment="Center" Click="CheckBookmark_Click"/>
+                    </Border>
+
+                    <Border Grid.Row="2" Grid.Column="2">
+                        <xctk:ColorPicker x:Name="ColorBookmark" SelectedColorChanged="ColorBookmark_SelectedColorChanged"/>
+                    </Border>
+
+                    <Border Grid.Row="2" Grid.Column="3">
+                        <xctk:ColorPicker x:Name="ColorBookmarkName" SelectedColorChanged="ColorBookmarkName_SelectedColorChanged"/>
+                    </Border>
+
+                    <Border Grid.Row="2" Grid.Column="4">
+                        <StackPanel Orientation="Horizontal">
+                            <Slider x:Name="SliderBookmarkShadowOpacity" Minimum="0" Maximum="1" Width="70" VerticalAlignment="Center" ValueChanged="SliderBookmarkShadowOpacity_ValueChanged" MouseDoubleClick="SliderBookmarkShadowOpacity_MouseDoubleClick"/>
+                            <Label Content="{Binding ElementName=SliderBookmarkShadowOpacity, Path=Value}"/>
+                        </StackPanel>
+                    </Border>
+
+                    <Border Grid.Row="2" Grid.Column="5">
+                        <Button x:Name="ButtonResetBookmark" Width="40" Click="ButtonResetBookmark_Click">Reset</Button>
+                    </Border>
+
+                    <Border Grid.Row="3" Grid.Column="0">
+                        <TextBlock HorizontalAlignment="Right" VerticalAlignment="Center">Timing Changes</TextBlock>
+                    </Border>
+
+                    <Border Grid.Row="3" Grid.Column="1">
+                        <CheckBox x:Name="CheckBPMChange" HorizontalAlignment="Center" VerticalAlignment="Center" Click="CheckBPMChange_Click"/>
+                    </Border>
+
+                    <Border Grid.Row="3" Grid.Column="2">
+                        <xctk:ColorPicker x:Name="ColorBPMChange" SelectedColorChanged="ColorBPMChange_SelectedColorChanged"/>
+                    </Border>
+
+                    <Border Grid.Row="3" Grid.Column="3">
+                        <xctk:ColorPicker x:Name="ColorBPMChangeLabel" SelectedColorChanged="ColorBPMChangeLabel_SelectedColorChanged"/>
+                    </Border>
+
+                    <Border Grid.Row="3" Grid.Column="4">
+                        <StackPanel Orientation="Horizontal">
+                            <Slider x:Name="SliderBPMChangeShadowOpacity" Minimum="0" Maximum="1" Width="70" VerticalAlignment="Center" ValueChanged="SliderBPMChangeShadowOpacity_ValueChanged" MouseDoubleClick="SliderBPMChangeShadowOpacity_MouseDoubleClick"/>
+                            <Label Content="{Binding ElementName=SliderBPMChangeShadowOpacity, Path=Value}"/>
+                        </StackPanel>
+                    </Border>
+
+                    <Border Grid.Row="3" Grid.Column="5">
+                        <Button x:Name="ButtonResetBPMChange" Width="40" Click="ButtonResetBPMChange_Click">Reset</Button>
+                    </Border>
+
+                    <Border Grid.Row="4" Grid.Column="0">
+                        <TextBlock HorizontalAlignment="Right" VerticalAlignment="Center">Notes</TextBlock>
+                    </Border>
+
+                    <Border Grid.Row="4" Grid.Column="1">
+                        <CheckBox x:Name="CheckNote" HorizontalAlignment="Center" VerticalAlignment="Center" Click="CheckNote_Click"/>
+                    </Border>
+
+                    <Border Grid.Row="4" Grid.Column="2">
+                        <xctk:ColorPicker x:Name="ColorNote" SelectedColorChanged="ColorNote_SelectedColorChanged"/>
+                    </Border>
+
+                    <Border Grid.Row="4" Grid.Column="3">
+                        <xctk:ColorPicker x:Name="ColorSelectedNote" SelectedColorChanged="ColorSelectedNote_SelectedColorChanged"/>
+                    </Border>
+
+                    <Border Grid.Row="4" Grid.Column="5">
+                        <Button x:Name="ButtonResetNote" Width="40" Click="ButtonResetNote_Click">Reset</Button>
+                    </Border>
+
+                </Grid>
+            </StackPanel>
+        </DockPanel>
+    </Grid>
+</Window>

--- a/Windows/CustomizeNavBarWindow.xaml
+++ b/Windows/CustomizeNavBarWindow.xaml
@@ -3,7 +3,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+    xmlns:colorpicker="clr-namespace:ColorPicker;assembly=ColorPicker"
     mc:Ignorable="d"
     Title="Customize Navigational Bar" Name="Window" Width="450" MinWidth="450" MaxWidth="450" Height="260" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" Background="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}">
     <Grid>
@@ -42,7 +42,6 @@
                         <ColumnDefinition Width="95" />
                         <ColumnDefinition Width="40" />
                         <ColumnDefinition Width="60" />
-                        <ColumnDefinition Width="60" />
                         <ColumnDefinition Width="100" />
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
@@ -53,10 +52,6 @@
 
                     <Border Grid.Row="0" Grid.Column="2">
                         <TextBlock FontWeight="DemiBold" HorizontalAlignment="Center" VerticalAlignment="Center">Color</TextBlock>
-                    </Border>
-
-                    <Border Grid.Row="0" Grid.Column="3">
-                        <TextBlock FontWeight="DemiBold" HorizontalAlignment="Center" VerticalAlignment="Center">Color #2</TextBlock>
                     </Border>
 
                     <Border Grid.Row="0" Grid.Column="4">
@@ -72,10 +67,10 @@
                     </Border>
 
                     <Border Grid.Row="1" Grid.Column="2">
-                        <xctk:ColorPicker x:Name="ColorWaveform" SelectedColorChanged="ColorWaveform_SelectedColorChanged" LostFocus="ColorWaveform_LostFocus"/>
+                        <colorpicker:PortableColorPicker x:Name="ColorWaveform" Height="20" ShowFractionalPart="False"/>
                     </Border>
 
-                    <Border Grid.Row="1" Grid.Column="5">
+                    <Border Grid.Row="1" Grid.Column="4">
                         <Button x:Name="ButtonResetWaveform" Width="40" Click="ButtonResetWaveform_Click">Reset</Button>
                     </Border>
 
@@ -88,21 +83,17 @@
                     </Border>
 
                     <Border Grid.Row="2" Grid.Column="2">
-                        <xctk:ColorPicker x:Name="ColorBookmark" SelectedColorChanged="ColorBookmark_SelectedColorChanged"/>
+                        <colorpicker:PortableColorPicker x:Name="ColorBookmark" Height="20" ShowFractionalPart="False"/>
                     </Border>
 
                     <Border Grid.Row="2" Grid.Column="3">
-                        <xctk:ColorPicker x:Name="ColorBookmarkName" SelectedColorChanged="ColorBookmarkName_SelectedColorChanged"/>
-                    </Border>
-
-                    <Border Grid.Row="2" Grid.Column="4">
                         <StackPanel Orientation="Horizontal">
                             <Slider x:Name="SliderBookmarkShadowOpacity" Minimum="0" Maximum="1" Width="70" VerticalAlignment="Center" ValueChanged="SliderBookmarkShadowOpacity_ValueChanged" MouseDoubleClick="SliderBookmarkShadowOpacity_MouseDoubleClick"/>
                             <Label Content="{Binding ElementName=SliderBookmarkShadowOpacity, Path=Value}"/>
                         </StackPanel>
                     </Border>
 
-                    <Border Grid.Row="2" Grid.Column="5">
+                    <Border Grid.Row="2" Grid.Column="4">
                         <Button x:Name="ButtonResetBookmark" Width="40" Click="ButtonResetBookmark_Click">Reset</Button>
                     </Border>
 
@@ -115,21 +106,17 @@
                     </Border>
 
                     <Border Grid.Row="3" Grid.Column="2">
-                        <xctk:ColorPicker x:Name="ColorBPMChange" SelectedColorChanged="ColorBPMChange_SelectedColorChanged"/>
+                        <colorpicker:PortableColorPicker x:Name="ColorBPMChange" Height="20" ShowFractionalPart="False"/>
                     </Border>
 
                     <Border Grid.Row="3" Grid.Column="3">
-                        <xctk:ColorPicker x:Name="ColorBPMChangeLabel" SelectedColorChanged="ColorBPMChangeLabel_SelectedColorChanged"/>
-                    </Border>
-
-                    <Border Grid.Row="3" Grid.Column="4">
                         <StackPanel Orientation="Horizontal">
                             <Slider x:Name="SliderBPMChangeShadowOpacity" Minimum="0" Maximum="1" Width="70" VerticalAlignment="Center" ValueChanged="SliderBPMChangeShadowOpacity_ValueChanged" MouseDoubleClick="SliderBPMChangeShadowOpacity_MouseDoubleClick"/>
                             <Label Content="{Binding ElementName=SliderBPMChangeShadowOpacity, Path=Value}"/>
                         </StackPanel>
                     </Border>
 
-                    <Border Grid.Row="3" Grid.Column="5">
+                    <Border Grid.Row="3" Grid.Column="4">
                         <Button x:Name="ButtonResetBPMChange" Width="40" Click="ButtonResetBPMChange_Click">Reset</Button>
                     </Border>
 
@@ -142,14 +129,10 @@
                     </Border>
 
                     <Border Grid.Row="4" Grid.Column="2">
-                        <xctk:ColorPicker x:Name="ColorNote" SelectedColorChanged="ColorNote_SelectedColorChanged"/>
+                        <colorpicker:PortableColorPicker x:Name="ColorNote" Height="20" ShowFractionalPart="False"/>
                     </Border>
 
-                    <Border Grid.Row="4" Grid.Column="3">
-                        <xctk:ColorPicker x:Name="ColorSelectedNote" SelectedColorChanged="ColorSelectedNote_SelectedColorChanged"/>
-                    </Border>
-
-                    <Border Grid.Row="4" Grid.Column="5">
+                    <Border Grid.Row="4" Grid.Column="4">
                         <Button x:Name="ButtonResetNote" Width="40" Click="ButtonResetNote_Click">Reset</Button>
                     </Border>
 

--- a/Windows/CustomizeNavBarWindow.xaml.cs
+++ b/Windows/CustomizeNavBarWindow.xaml.cs
@@ -1,0 +1,203 @@
+﻿using Edda.Const;
+using System.Windows;
+using System.Windows.Media;
+
+namespace Edda {
+    /// <summary>
+    /// Interaction logic for CustomizeNavBarWindow.xaml
+    /// </summary>
+    public partial class CustomizeNavBarWindow : Window {
+        readonly MainWindow caller;
+        readonly UserSettingsManager userSettings;
+        readonly bool doneInit = false;
+        public CustomizeNavBarWindow(MainWindow caller, UserSettingsManager userSettings) {
+            InitializeComponent();
+            this.caller = caller;
+            this.userSettings = userSettings;
+
+            CheckWaveform.IsChecked = userSettings.GetBoolForKey(UserSettingsKey.EnableNavWaveform);
+            var waveformColor = userSettings.GetValueForKey(UserSettingsKey.NavWaveformColor) ?? Editor.Waveform.ColourWPF.ToString();
+            ColorWaveform.SelectedColor = (Color)ColorConverter.ConvertFromString(waveformColor);
+            ToggleWaveformColorIsEnabled();
+
+            CheckBookmark.IsChecked = userSettings.GetBoolForKey(UserSettingsKey.EnableNavBookmarks);
+            ColorBookmark.SelectedColor = (Color)ColorConverter.ConvertFromString(userSettings.GetValueForKey(UserSettingsKey.NavBookmarkColor) ?? Editor.NavBookmark.Colour);
+            ColorBookmarkName.SelectedColor = (Color)ColorConverter.ConvertFromString(userSettings.GetValueForKey(UserSettingsKey.NavBookmarkNameColor) ?? Editor.NavBookmark.NameColour);
+            SliderBookmarkShadowOpacity.Value = double.Parse(userSettings.GetValueForKey(UserSettingsKey.NavBookmarkShadowOpacity));
+            ToggleBookmarkColorIsEnabled();
+
+            CheckBPMChange.IsChecked = userSettings.GetBoolForKey(UserSettingsKey.EnableNavBPMChanges);
+            ColorBPMChange.SelectedColor = (Color)ColorConverter.ConvertFromString(userSettings.GetValueForKey(UserSettingsKey.NavBPMChangeColor) ?? Editor.NavBPMChange.Colour);
+            ColorBPMChangeLabel.SelectedColor = (Color)ColorConverter.ConvertFromString(userSettings.GetValueForKey(UserSettingsKey.NavBPMChangeLabelColor) ?? Editor.NavBPMChange.LabelColour);
+            SliderBPMChangeShadowOpacity.Value = double.Parse(userSettings.GetValueForKey(UserSettingsKey.NavBPMChangeShadowOpacity));
+            ToggleBPMChangeColorIsEnabled();
+
+            CheckNote.IsChecked = userSettings.GetBoolForKey(UserSettingsKey.EnableNavNotes);
+            ColorNote.SelectedColor = (Color)ColorConverter.ConvertFromString(userSettings.GetValueForKey(UserSettingsKey.NavNoteColor) ?? Editor.NavNote.Colour);
+            ColorSelectedNote.SelectedColor = (Color)ColorConverter.ConvertFromString(userSettings.GetValueForKey(UserSettingsKey.NavSelectedNoteColor) ?? Editor.NavNote.HighlightColour);
+            ToggleNoteColorIsEnabled();
+
+            doneInit = true;
+        }
+
+        private void BtnSave_Click(object sender, RoutedEventArgs e) {
+            Close();
+        }
+
+        private void UpdateSettings() {
+            userSettings.Write();
+            caller.LoadSettingsFile();
+        }
+
+        private void UpdateWaveform() {
+            UpdateSettings();
+            caller.gridController.DrawNavWaveform();
+        }
+
+        private void UpdateBookmarks() {
+            UpdateSettings();
+            caller.gridController.DrawNavBookmarks();
+        }
+
+        private void UpdateBPMChanges() {
+            UpdateSettings();
+            caller.gridController.DrawNavBPMChanges();
+        }
+
+        private void UpdateNotes() {
+            UpdateSettings();
+            caller.canvasNavNotes.Children.Clear();
+            caller.gridController.DrawNavNotes(caller.mapEditor.currentMapDifficulty.notes);
+            caller.gridController.HighlightNavNotes(caller.mapEditor.currentMapDifficulty.selectedNotes);
+        }
+
+        private void CheckWaveform_Click(object sender, RoutedEventArgs e) {
+            ToggleWaveformColorIsEnabled();
+            userSettings.SetValueForKey(UserSettingsKey.EnableNavWaveform, CheckWaveform.IsChecked ?? false);
+            UpdateWaveform();
+        }
+        private void ColorWaveform_SelectedColorChanged(object sender, RoutedPropertyChangedEventArgs<Color?> e) {
+            if (doneInit) {
+                userSettings.SetValueForKey(UserSettingsKey.NavWaveformColor, (ColorWaveform.SelectedColor ?? Editor.Waveform.ColourWPF).ToString());
+            }
+        }
+        private void ColorWaveform_LostFocus(object sender, RoutedEventArgs e) {
+            if (doneInit) {
+                UpdateWaveform();
+            }
+        }
+        private void ToggleWaveformColorIsEnabled() {
+            ColorWaveform.IsEnabled = CheckWaveform.IsChecked ?? false;
+        }
+
+        private void CheckBookmark_Click(object sender, RoutedEventArgs e) {
+            ToggleBookmarkColorIsEnabled();
+            userSettings.SetValueForKey(UserSettingsKey.EnableNavBookmarks, CheckBookmark.IsChecked ?? false);
+            UpdateBookmarks();
+        }
+        private void ColorBookmark_SelectedColorChanged(object sender, RoutedPropertyChangedEventArgs<Color?> e) {
+            if (doneInit) {
+                userSettings.SetValueForKey(UserSettingsKey.NavBookmarkColor, ColorBookmark.SelectedColor.ToString() ?? Editor.NavBookmark.Colour);
+                UpdateBookmarks();
+            }
+        }
+        private void ColorBookmarkName_SelectedColorChanged(object sender, RoutedPropertyChangedEventArgs<Color?> e) {
+            if (doneInit) {
+                userSettings.SetValueForKey(UserSettingsKey.NavBookmarkNameColor, ColorBookmarkName.SelectedColor.ToString() ?? Editor.NavBookmark.NameColour);
+                UpdateBookmarks();
+            }
+        }
+        private void SliderBookmarkShadowOpacity_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e) {
+            if (doneInit) {
+                userSettings.SetValueForKey(UserSettingsKey.NavBookmarkShadowOpacity, SliderBookmarkShadowOpacity.Value.ToString());
+                UpdateBookmarks();
+            }
+        }
+        private void SliderBookmarkShadowOpacity_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e) {
+            SliderBookmarkShadowOpacity.Value = Editor.NavBookmark.ShadowOpacity;
+        }
+        private void ToggleBookmarkColorIsEnabled() {
+            var status = CheckBookmark.IsChecked ?? false;
+            ColorBookmark.IsEnabled = status;
+            ColorBookmarkName.IsEnabled = status;
+            SliderBookmarkShadowOpacity.IsEnabled = status;
+        }
+
+        private void CheckBPMChange_Click(object sender, RoutedEventArgs e) {
+            ToggleBPMChangeColorIsEnabled();
+            userSettings.SetValueForKey(UserSettingsKey.EnableNavBPMChanges, CheckBPMChange.IsChecked ?? false);
+            UpdateBPMChanges();
+        }
+        private void ColorBPMChange_SelectedColorChanged(object sender, RoutedPropertyChangedEventArgs<Color?> e) {
+            if (doneInit) {
+                userSettings.SetValueForKey(UserSettingsKey.NavBPMChangeColor, ColorBPMChange.SelectedColor.ToString() ?? Editor.NavBPMChange.Colour);
+                UpdateBPMChanges();
+            }
+        }
+        private void ColorBPMChangeLabel_SelectedColorChanged(object sender, RoutedPropertyChangedEventArgs<Color?> e) {
+            if (doneInit) {
+                userSettings.SetValueForKey(UserSettingsKey.NavBPMChangeLabelColor, ColorBPMChangeLabel.SelectedColor.ToString() ?? Editor.NavBPMChange.LabelColour);
+                UpdateBPMChanges();
+            }
+        }
+        private void SliderBPMChangeShadowOpacity_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e) {
+            if (doneInit) {
+                userSettings.SetValueForKey(UserSettingsKey.NavBPMChangeShadowOpacity, SliderBPMChangeShadowOpacity.Value.ToString());
+                UpdateBPMChanges();
+            }
+        }
+        private void SliderBPMChangeShadowOpacity_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e) {
+            SliderBPMChangeShadowOpacity.Value = Editor.NavBPMChange.ShadowOpacity;
+        }
+        private void ToggleBPMChangeColorIsEnabled() {
+            var status = CheckBPMChange.IsChecked ?? false;
+            ColorBPMChange.IsEnabled = status;
+            ColorBPMChangeLabel.IsEnabled = status;
+            SliderBPMChangeShadowOpacity.IsEnabled = status;
+        }
+
+        private void CheckNote_Click(object sender, RoutedEventArgs e) {
+            ToggleNoteColorIsEnabled();
+            userSettings.SetValueForKey(UserSettingsKey.EnableNavNotes, CheckNote.IsChecked ?? false);
+            UpdateNotes();
+        }
+        private void ColorNote_SelectedColorChanged(object sender, RoutedPropertyChangedEventArgs<Color?> e) {
+            if (doneInit) {
+                userSettings.SetValueForKey(UserSettingsKey.NavNoteColor, ColorNote.SelectedColor.ToString() ?? Editor.NavNote.Colour);
+                UpdateNotes();
+            }
+        }
+        private void ColorSelectedNote_SelectedColorChanged(object sender, RoutedPropertyChangedEventArgs<Color?> e) {
+            if (doneInit) {
+                userSettings.SetValueForKey(UserSettingsKey.NavSelectedNoteColor, ColorSelectedNote.SelectedColor.ToString() ?? Editor.NavNote.HighlightColour);
+                UpdateNotes();
+            }
+        }
+        private void ToggleNoteColorIsEnabled() {
+            ColorNote.IsEnabled = CheckNote.IsChecked ?? false;
+            ColorSelectedNote.IsEnabled = CheckNote.IsChecked ?? false;
+        }
+
+        private void ButtonResetWaveform_Click(object sender, RoutedEventArgs e) {
+            ColorWaveform.SelectedColor = Editor.Waveform.ColourWPF;
+            UpdateWaveform();
+        }
+
+        private void ButtonResetBookmark_Click(object sender, RoutedEventArgs e) {
+            ColorBookmark.SelectedColor = (Color)ColorConverter.ConvertFromString(Editor.NavBookmark.Colour);
+            ColorBookmarkName.SelectedColor = (Color)ColorConverter.ConvertFromString(Editor.NavBookmark.NameColour);
+            SliderBookmarkShadowOpacity.Value = Editor.NavBookmark.ShadowOpacity;
+        }
+
+        private void ButtonResetBPMChange_Click(object sender, RoutedEventArgs e) {
+            ColorBPMChange.SelectedColor = (Color)ColorConverter.ConvertFromString(Editor.NavBPMChange.Colour);
+            ColorBPMChangeLabel.SelectedColor = (Color)ColorConverter.ConvertFromString(Editor.NavBPMChange.LabelColour);
+            SliderBPMChangeShadowOpacity.Value = Editor.NavBPMChange.ShadowOpacity;
+        }
+
+        private void ButtonResetNote_Click(object sender, RoutedEventArgs e) {
+            ColorNote.SelectedColor = (Color)ColorConverter.ConvertFromString(Editor.NavNote.Colour);
+            ColorSelectedNote.SelectedColor = (Color)ColorConverter.ConvertFromString(Editor.NavNote.HighlightColour);
+        }
+    }
+}

--- a/Windows/MainWindow.GridControls.cs
+++ b/Windows/MainWindow.GridControls.cs
@@ -24,6 +24,10 @@ namespace Edda {
                 var lineY = sliderSongProgress.Value / sliderSongProgress.Maximum * borderNavWaveform.ActualHeight;
                 gridController.DrawNavWaveform();
                 gridController.DrawNavBookmarks();
+                gridController.DrawNavBPMChanges();
+                canvasNavNotes.Children.Clear();
+                gridController.DrawNavNotes(mapEditor.currentMapDifficulty.notes);
+                gridController.HighlightNavNotes(mapEditor.currentMapDifficulty.selectedNotes);
                 gridController.SetSongMouseoverLinePosition(lineY);
             }
         }

--- a/Windows/MainWindow.UIControls.cs
+++ b/Windows/MainWindow.UIControls.cs
@@ -504,6 +504,19 @@ namespace Edda {
                 win.Focus();
             }
         }
+
+        private void BtnCustomizeNavBar_Click(object sender, RoutedEventArgs e) {
+            var win = Helper.GetFirstWindow<CustomizeNavBarWindow>();
+            if (win == null) {
+                win = new CustomizeNavBarWindow(this, userSettings);
+                win.Topmost = true;
+                win.Owner = this;
+                win.Show();
+            } else {
+                win.Focus();
+            }
+        }
+
         private void TxtSongOffset_LostFocus(object sender, RoutedEventArgs e) {
             double offset;
             double prevOffset = Helper.DoubleParseInvariant((string)mapEditor.GetMapValue("_songTimeOffset"));

--- a/Windows/MainWindow.UIControls.cs
+++ b/Windows/MainWindow.UIControls.cs
@@ -31,6 +31,8 @@ namespace Edda {
         private void AppMainWindow_Closed(object sender, EventArgs e) {
             Trace.WriteLine("INFO: Closing main window...");
 
+            editorIsLoaded = false;
+
             // Audio resources
             if (deviceEnumerator != null) {
                 if (deviceChangeListener != null) {

--- a/Windows/MainWindow.xaml
+++ b/Windows/MainWindow.xaml
@@ -601,14 +601,24 @@
                             </Grid.ColumnDefinitions>
 
                             <Border Grid.Row="0" Grid.ColumnSpan="2" Margin="0 0 0 5" Padding="0 5 0 10">
-                                <Button x:Name="btnChangeBPM" Width="199" Padding="3" HorizontalAlignment="Center" Click="BtnChangeBPM_Click">
-                                    <Button.Resources>
-                                        <Style TargetType="Border">
-                                            <Setter Property="CornerRadius" Value="5"/>
-                                        </Style>
-                                    </Button.Resources> 
-                                    Edit Song Timing
-                                </Button>
+                                <StackPanel Orientation="Vertical">
+                                    <Button x:Name="btnChangeBPM" Width="199" Padding="3" Margin="0 0 0 5" HorizontalAlignment="Center" Click="BtnChangeBPM_Click">
+                                        <Button.Resources>
+                                            <Style TargetType="Border">
+                                                <Setter Property="CornerRadius" Value="5"/>
+                                            </Style>
+                                        </Button.Resources> 
+                                        Edit Song Timing
+                                    </Button>
+                                    <Button x:Name="btnCustomizeNavBar" Width="199" Padding="3" HorizontalAlignment="Center" Click="BtnCustomizeNavBar_Click">
+                                        <Button.Resources>
+                                            <Style TargetType="Border">
+                                                <Setter Property="CornerRadius" Value="5"/>
+                                            </Style>
+                                        </Button.Resources>
+                                        Customize Navigation Bar
+                                    </Button>
+                                </StackPanel>
                             </Border>
 
                             <Border Grid.Row="1" Grid.Column="0" Padding="5 0 0 5">
@@ -717,10 +727,13 @@
             <Border x:Name="borderNavWaveform" Grid.Column="2" BorderBrush="{DynamicResource {x:Static SystemColors.ControlDarkDarkBrushKey}}" BorderThickness="1 0 0 0" Background="#20000000" MouseMove="BorderNavWaveform_MouseMove" MouseEnter="BorderNavWaveform_MouseEnter" MouseLeave="BorderNavWaveform_MouseLeave" MouseLeftButtonDown="BorderNavWaveform_MouseLeftButtonDown" MouseLeftButtonUp="BorderNavWaveform_MouseLeftButtonUp">
                 <Grid>
                     <Image x:Name="imgWaveformVertical" Width="{Binding ElementName=borderNavWaveform, Path=ActualWidth}"/>
+                    <Canvas x:Name="canvasNavNotes"/>
                     <Line x:Name="lineSongMouseover" StrokeThickness="1" X2="{Binding ElementName=borderNavWaveform, Path=ActualWidth}"></Line>
                     <Canvas x:Name="canvasBookmarks"/>
+                    <Canvas x:Name="canvasTimingChanges"/>
                     <Line x:Name="lineSongProgress" Stroke="Navy" StrokeThickness="1" X2="{Binding ElementName=borderNavWaveform, Path=ActualWidth}" Y1="{Binding ElementName=borderNavWaveform, Path=ActualHeight}" Y2="{Binding ElementName=borderNavWaveform, Path=ActualHeight}"/>
                     <Canvas x:Name="canvasBookmarkLabels"/>
+                    <Canvas x:Name="canvasTimingChangeLabels"/>
                     <Canvas x:Name="canvasNavInputBox"/>
                 </Grid>
             </Border>

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -1270,6 +1270,7 @@ namespace Edda {
             sliderSongProgress.IsEnabled = false;
             borderNavWaveform.IsEnabled = false;
             sliderSongTempo.IsEnabled = false;
+            btnCustomizeNavBar.IsEnabled = false;
 
             // stop preview from interfering
             songPreviewController?.StopPreview();
@@ -1332,6 +1333,7 @@ namespace Edda {
             sliderSongProgress.IsEnabled = true;
             borderNavWaveform.IsEnabled = true;
             sliderSongTempo.IsEnabled = true;
+            btnCustomizeNavBar.IsEnabled = true;
             songPreviewController?.EnablePreviewButton();
 
             // reset scroll animation

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -199,8 +199,11 @@ namespace Edda {
                 panelSpectrogram,
                 EditorMarginGrid,
                 canvasNavInputBox,
+                canvasNavNotes,
                 canvasBookmarks,
                 canvasBookmarkLabels,
+                canvasTimingChanges,
+                canvasTimingChangeLabels,
                 lineSongMouseover
             );
             // load preview UI
@@ -634,6 +637,7 @@ namespace Edda {
             sliderSongProgress.IsEnabled = true;
             scrollEditor.IsEnabled = true;
             borderNavWaveform.IsEnabled = true;
+            btnCustomizeNavBar.IsEnabled = true;
         }
         private void DisableUI() {
             btnChangeDifficulty0.IsEnabled = false;
@@ -669,6 +673,7 @@ namespace Edda {
             sliderSongProgress.IsEnabled = false;
             scrollEditor.IsEnabled = false;
             borderNavWaveform.IsEnabled = false;
+            btnCustomizeNavBar.IsEnabled = false;
         }
         private void ToggleLeftDock() {
             if (borderLeftDock.Visibility == Visibility.Collapsed) {
@@ -832,6 +837,34 @@ namespace Edda {
                 userSettings.SetValueForKey(UserSettingsKey.DifficultyPredictorShowInMapStats, DefaultUserSettings.DifficultyPredictorShowInMapStats);
             }
 
+            if (userSettings.GetValueForKey(UserSettingsKey.EnableNavWaveform) == null) {
+                userSettings.SetValueForKey(UserSettingsKey.EnableNavWaveform, DefaultUserSettings.EnableNavWaveform);
+            }
+
+            if (userSettings.GetValueForKey(UserSettingsKey.EnableNavBookmarks) == null) {
+                userSettings.SetValueForKey(UserSettingsKey.EnableNavBookmarks, DefaultUserSettings.EnableNavBookmarks);
+            }
+
+            try {
+                double.Parse(userSettings.GetValueForKey(UserSettingsKey.NavBookmarkShadowOpacity));
+            } catch {
+                userSettings.SetValueForKey(UserSettingsKey.NavBookmarkShadowOpacity, Editor.NavBookmark.ShadowOpacity);
+            }
+
+            if (userSettings.GetValueForKey(UserSettingsKey.EnableNavBPMChanges) == null) {
+                userSettings.SetValueForKey(UserSettingsKey.EnableNavBPMChanges, DefaultUserSettings.EnableNavBPMChanges);
+            }
+
+            try {
+                double.Parse(userSettings.GetValueForKey(UserSettingsKey.NavBPMChangeShadowOpacity));
+            } catch {
+                userSettings.SetValueForKey(UserSettingsKey.NavBPMChangeShadowOpacity, Editor.NavBPMChange.ShadowOpacity);
+            }
+
+            if (userSettings.GetValueForKey(UserSettingsKey.EnableNavNotes) == null) {
+                userSettings.SetValueForKey(UserSettingsKey.EnableNavNotes, DefaultUserSettings.EnableNavNotes);
+            }
+
             userSettings.Write();
         }
         internal void LoadSettingsFile(bool reloadWaveforms = false) {
@@ -894,6 +927,12 @@ namespace Edda {
             SetDiscordRPC(userSettings.GetBoolForKey(UserSettingsKey.EnableDiscordRPC));
             autosaveTimer.Enabled = userSettings.GetBoolForKey(UserSettingsKey.EnableAutosave);
 
+            imgWaveformVertical.Visibility = userSettings.GetBoolForKey(UserSettingsKey.EnableNavWaveform) ? Visibility.Visible : Visibility.Hidden;
+            canvasBookmarks.Visibility = userSettings.GetBoolForKey(UserSettingsKey.EnableNavBookmarks) ? Visibility.Visible : Visibility.Hidden;
+            canvasBookmarkLabels.Visibility = userSettings.GetBoolForKey(UserSettingsKey.EnableNavBookmarks) ? Visibility.Visible : Visibility.Hidden;
+            canvasTimingChanges.Visibility = userSettings.GetBoolForKey(UserSettingsKey.EnableNavBPMChanges) ? Visibility.Visible : Visibility.Hidden;
+            canvasTimingChangeLabels.Visibility = userSettings.GetBoolForKey(UserSettingsKey.EnableNavBPMChanges) ? Visibility.Visible : Visibility.Hidden;
+            canvasNavNotes.Visibility = userSettings.GetBoolForKey(UserSettingsKey.EnableNavNotes) ? Visibility.Visible : Visibility.Hidden;
         }
 
         internal string GetUserSetting(string key) {


### PR DESCRIPTION
#82 

Implemented visual indicators for placed notes and timing changes on the navigational waveform:
![image](https://github.com/user-attachments/assets/62ef3163-11f5-4008-93c9-ebd91647b4ed)

Since the navigation bar can get crowded, there's also a new button in the right panel that opens a window for customizing what shows up there and what colors are used:
![image](https://github.com/user-attachments/assets/5787cf00-fecd-4e0c-8fd4-83d61be66fbc)

![image](https://github.com/user-attachments/assets/7c5e358d-f912-4b79-8aa8-1c62d6063703)

![image](https://github.com/user-attachments/assets/1da98db7-c532-4f77-8cd2-b875c2517a39)

