### PR TITLE
OneDrive causes crashes when saving

### DIFF
--- a/Classes/Helper.cs
+++ b/Classes/Helper.cs
@@ -392,4 +392,34 @@ public partial class Helper {
         };
         return BitmapGenerator($"rune{runeStr}{(isHighlighted ? "highlight" : "")}.png");
     }
+
+    // https://stackoverflow.com/questions/329355/cannot-delete-directory-with-directory-deletepath-true
+    public static void DeleteDirectory(string target_dir) {
+        string[] files = Directory.GetFiles(target_dir);
+        string[] dirs = Directory.GetDirectories(target_dir);
+
+        foreach (string file in files) {
+            File.SetAttributes(file, FileAttributes.Normal);
+            File.Delete(file);
+        }
+
+        foreach (string dir in dirs) {
+            DeleteDirectory(dir);
+        }
+
+        try {
+            Directory.Delete(target_dir, false);
+        } catch (IOException ex) {
+            Trace.WriteLine(ex);
+            ShowOneDriveWarning();
+        }
+    }
+    public static void ShowOneDriveWarning() {
+        MessageBox.Show(
+            "There's been an issue with managing map files, likely due to OneDrive or similar application blocking Edda from accessing the files.\n\nPlease consider disabling OneDrive on the folder where the map is stored, to avoid losing work.",
+            "Warning",
+            MessageBoxButton.OK,
+            MessageBoxImage.Warning
+        );
+    }
 }

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -431,23 +431,6 @@ namespace Edda {
             */
         }
         private void BackupAndSaveBeatmap() {
-            // https://stackoverflow.com/questions/329355/cannot-delete-directory-with-directory-deletepath-true
-            void DeleteDirectory(string target_dir) {
-                string[] files = Directory.GetFiles(target_dir);
-                string[] dirs = Directory.GetDirectories(target_dir);
-
-                foreach (string file in files) {
-                    File.SetAttributes(file, FileAttributes.Normal);
-                    File.Delete(file);
-                }
-
-                foreach (string dir in dirs) {
-                    DeleteDirectory(dir);
-                }
-
-                Directory.Delete(target_dir, false);
-            }
-
             // save beatmap
             SaveBeatmap();
 
@@ -480,7 +463,7 @@ namespace Edda {
 
             // delete oldest backup if we have too many
             if (existingBackups.Count == Program.MaxBackups) {
-                DeleteDirectory(existingBackups[0]);
+                Helper.DeleteDirectory(existingBackups[0]);
             }
 
             // make new backup file
@@ -538,7 +521,7 @@ namespace Edda {
                 // --
 
                 if (Directory.Exists(zipFolder)) {
-                    Directory.Delete(zipFolder, true);
+                    Helper.DeleteDirectory(zipFolder);
                 }
                 Directory.CreateDirectory(zipFolder);
 
@@ -553,7 +536,7 @@ namespace Edda {
                 MessageBox.Show(this, $"An error occured while creating the zip file.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
             } finally {
                 if (Directory.Exists(zipFolder)) {
-                    Directory.Delete(zipFolder, true);
+                    Helper.DeleteDirectory(zipFolder);
                 }
             }
         }
@@ -1176,7 +1159,7 @@ namespace Edda {
         internal void ClearSongCache() {
             var cacheDirectoryPath = Path.Combine(mapEditor.mapFolder, Program.CachePath);
             if (Directory.Exists(cacheDirectoryPath)) {
-                Directory.Delete(cacheDirectoryPath, true);
+                Helper.DeleteDirectory(cacheDirectoryPath);
             }
         }
         private void InitSongPlayer() {


### PR DESCRIPTION
#150 

Implemented a failsafe in case there's an access issue on Edda-managed map files, e.g. due to OneDrive blocking the access due to ongoing sync.

EDIT: ignore the name of the branch, I goofed up