### PR TITLE
Waveform renders on top of the runes after starting Edda

### DIFF
--- a/Classes/UI/EditorGridController.cs
+++ b/Classes/UI/EditorGridController.cs
@@ -27,6 +27,7 @@ public class EditorGridController : IDisposable {
 
     // constructor variables
     MainWindow parentWindow;
+    Canvas MainWaveform;
     Canvas EditorGrid;
     ScrollViewer scrollEditor;
     ColumnDefinition referenceCol;
@@ -170,6 +171,7 @@ public class EditorGridController : IDisposable {
     // constructor
     public EditorGridController(
         MainWindow parentWindow,
+        Canvas MainWaveform,
         Canvas EditorGrid,
         ScrollViewer scrollEditor,
         ColumnDefinition referenceCol,
@@ -186,6 +188,7 @@ public class EditorGridController : IDisposable {
         Line lineSongMouseover
     ) {
         this.parentWindow = parentWindow;
+        this.MainWaveform = MainWaveform;
         this.EditorGrid = EditorGrid;
         this.referenceCol = referenceCol;
         this.referenceRow = referenceRow;
@@ -239,6 +242,7 @@ public class EditorGridController : IDisposable {
         // Clear the most memory-heavy components
         noteCanvas.Children.Clear();
         EditorGrid.Children.Clear();
+        MainWaveform.Children.Clear();
         panelSpectrogram.Children.Clear();
         imgWaveformVertical.Source = null;
         imgAudioWaveform.Source = null;
@@ -249,6 +253,7 @@ public class EditorGridController : IDisposable {
         // Unbind references
         mapEditor = null;
         parentWindow = null;
+        MainWaveform = null;
         EditorGrid = null;
         scrollEditor = null;
         referenceCol = null;
@@ -327,20 +332,20 @@ public class EditorGridController : IDisposable {
         }
     }
     public void DrawMainWaveform() {
-        if (!EditorGrid.Children.Contains(imgAudioWaveform)) {
-            EditorGrid.Children.Add(imgAudioWaveform);
+        if (!MainWaveform.Children.Contains(imgAudioWaveform)) {
+            MainWaveform.Children.Add(imgAudioWaveform);
         }
         ResizeMainWaveform();
-        double height = EditorGrid.Height - scrollEditor.ActualHeight;
-        double width = EditorGrid.ActualWidth * Editor.Waveform.Width;
+        double height = MainWaveform.Height - scrollEditor.ActualHeight;
+        double width = MainWaveform.ActualWidth * Editor.Waveform.Width;
         CreateMainWaveform(height, width);
     }
     public void UndrawMainWaveform() {
-        EditorGrid.Children.Remove(imgAudioWaveform);
+        MainWaveform.Children.Remove(imgAudioWaveform);
     }
     private void ResizeMainWaveform() {
-        imgAudioWaveform.Height = EditorGrid.Height - scrollEditor.ActualHeight;
-        imgAudioWaveform.Width = EditorGrid.ActualWidth;
+        imgAudioWaveform.Height = MainWaveform.Height - scrollEditor.ActualHeight;
+        imgAudioWaveform.Width = MainWaveform.ActualWidth;
         Canvas.SetBottom(imgAudioWaveform, unitHeight / 2);
     }
     private void CreateMainWaveform(double height, double width) {
@@ -458,9 +463,6 @@ public class EditorGridController : IDisposable {
         EditorGrid.Children.Add(l);
 
         // then draw the waveform
-        if (showWaveform) {
-            EditorGrid.Children.Add(imgAudioWaveform);
-        }
         if (redrawWaveform && EditorGrid.Height - scrollEditor.ActualHeight > 0) {
             DrawScrollingWaveforms();
         }

--- a/Windows/MainWindow.xaml
+++ b/Windows/MainWindow.xaml
@@ -811,7 +811,10 @@
                 </Grid>
                 <!-- Map Notes -->
                 <ScrollViewer x:Name="scrollEditor" VerticalScrollBarVisibility="Hidden" CanContentScroll="False" ScrollChanged="ScrollEditor_ScrollChanged" PreviewMouseWheel="ScrollEditor_PreviewMouseWheel" MouseMove="scrollEditor_MouseMove" MouseDown="scrollEditor_MouseDown" MouseUp="scrollEditor_MouseUp" MouseEnter="scrollEditor_MouseEnter" MouseLeave="scrollEditor_MouseLeave" PreviewMouseLeftButtonDown="scrollEditor_PreviewMouseLeftButtonDown" MouseLeftButtonUp="scrollEditor_PreviewMouseLeftButtonUp" MouseRightButtonUp="scrollEditor_PreviewMouseRightButtonUp" Loaded="scrollEditor_Loaded">
-                    <Canvas x:Name="EditorGrid"/>
+                    <Grid x:Name="EditorGridContainer">
+                        <Canvas x:Name="MainWaveform" Height="{Binding ElementName=EditorGrid, Path=Height}"/>
+                        <Canvas x:Name="EditorGrid"/>
+                    </Grid>
                 </ScrollViewer>
                 <Canvas x:Name="scrollEditorHoldScrollLayer" Visibility="Hidden" IsHitTestVisible="False">
                     <Image x:Name="scrollEditorHoldIcon" Width="30" Height="30" Source="pack://application:,,,/Edda;component/resources/scrollHold.png" RenderOptions.BitmapScalingMode="Fant"/>

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -188,6 +188,7 @@ namespace Edda {
             // load editor UI
             gridController = new EditorGridController(
                 this,
+                MainWaveform,
                 EditorGrid,
                 scrollEditor,
                 DrumCol,


### PR DESCRIPTION
#151 

Fixed an issue with waveform being rendered on top of the runes in some cases by giving it a separate Canvas.