### PR TITLE
Spectrogram sometimes doesn't align correctly

### DIFF
--- a/Classes/Audio/VorbisSpectrogramGenerator.cs
+++ b/Classes/Audio/VorbisSpectrogramGenerator.cs
@@ -4,6 +4,7 @@ using Spectrogram;
 using System;
 using System.Diagnostics;
 using System.Drawing;
+using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
@@ -206,6 +207,7 @@ public class VorbisSpectrogramGenerator : IDisposable {
                 var endPixel = source.Width * (i + 1) / numChunks;
                 Bitmap bmp = new Bitmap(endPixel - startPixel, source.Height);
                 using (Graphics g = Graphics.FromImage(bmp)) {
+                    g.PixelOffsetMode = PixelOffsetMode.HighQuality;
                     g.DrawImage(source, 0, 0, new Rectangle(startPixel, 0, bmp.Width, bmp.Height), GraphicsUnit.Pixel);
                 }
                 splitBmps[i] = bmp;

--- a/Classes/UI/EditorGridController.cs
+++ b/Classes/UI/EditorGridController.cs
@@ -417,9 +417,11 @@ public class EditorGridController : IDisposable {
 
             if (bmps != null && bmps.Length == numChunks) {
                 this.dispatcher.Invoke(() => {
+                    double totalBmpLength = bmps.Sum(bmp => bmp.Height);
                     for (int i = 0; i < numChunks; ++i) {
                         if (bmps != null) {
                             imgSpectrogramChunks[i].Source = bmps[i];
+                            imgSpectrogramChunks[i].Height = (EditorGrid.Height - scrollEditor.ActualHeight) * bmps[i].Height / totalBmpLength;
                         }
                     }
                     DrawingColor bgColor = audioSpectrogram.GetBackgroundColor();


### PR DESCRIPTION
#149 

This one was a doozy to debug... After multiple tests I finally narrowed the problem down to the way chunks are created using GDI.

The dynamic container height realignment makes the image jump a few pixels, but afterwards it aligns closer to the beat.