### PR TITLE
Bump version to 1.2.7

### DIFF
--- a/Classes/EddaConstants.cs
+++ b/Classes/EddaConstants.cs
@@ -13,7 +13,7 @@ namespace Edda.Const {
         public const string Name = "Edda";
         public const string RepositoryURL = "https://github.com/PKBeam/Edda";
         public const string ReleasesAPI = "https://api.github.com/repos/PKBeam/Edda/releases";
-        public const string BaseVersionString = "1.2.6";
+        public const string BaseVersionString = "1.2.7";
         public const string VersionString =
 #if DEBUG
             BaseVersionString + "-dev";


### PR DESCRIPTION
# New features
* Display notes on navigational waveform by @Brollyy in https://github.com/PKBeam/Edda/pull/148

# Bugfixes
* Beats don't match the song speed after changing difficulty by @Brollyy in https://github.com/PKBeam/Edda/pull/147
* Spectrogram sometimes doesn't align correctly by @Brollyy in https://github.com/PKBeam/Edda/pull/156
* Waveform renders on top of the runes after starting Edda by @Brollyy in https://github.com/PKBeam/Edda/pull/153
* OneDrive causes crashes when saving by @Brollyy in https://github.com/PKBeam/Edda/pull/152
* Fixed an issue with incorrect BPM values imported from SSC files. by @Brollyy in https://github.com/PKBeam/Edda/pull/155

# Other
For the list of the other features and bugfixes introduced in 1.2.7 compared to 1.2.6, please check release notes for [1.2.7 Beta 1](https://github.com/PKBeam/Edda/releases/tag/v1.2.7b1) and [1.2.7 Beta 2](https://github.com/PKBeam/Edda/releases/tag/v1.2.7b2).